### PR TITLE
Support multibyte characters

### DIFF
--- a/test/wkok/openai_clojure/sse_test.clj
+++ b/test/wkok/openai_clojure/sse_test.clj
@@ -1,0 +1,36 @@
+(ns wkok.openai-clojure.sse-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.core.async :as a]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [hato.client :as http]
+   [wkok.openai-clojure.sse :as sse])
+  (:import (java.io PipedInputStream PipedOutputStream)))
+
+(defn- generate-events
+  [data-coll]
+  (let [events (map #(str "data: " (json/generate-string %)) data-coll)]
+    (str/join "\n\n" (concat events ["data: [DONE]"]))))
+
+(defn- stream-string
+  [^PipedOutputStream output-stream ^String s]
+  (future
+    (doseq [c (seq (.getBytes s))]
+      (.write output-stream ^int c)
+      (.flush output-stream)
+      (Thread/sleep 1))))
+
+(deftest sse-events-test
+  (testing "channel can get events"
+    (let [test-data [{:text "hello"} {:text "world"}]
+          test-events (generate-events test-data)]
+      (with-open [output-stream (PipedOutputStream.)
+                  input-stream (PipedInputStream. output-stream)]
+        (with-redefs [http/request (constantly {:body input-stream})]
+          (let [events (sse/sse-events {})]
+            (stream-string output-stream test-events)
+            (is (= (first test-data)
+                   (a/<!! events)))
+            (is (= (second test-data)
+                   (a/<!! events)))))))))

--- a/test/wkok/openai_clojure/sse_test.clj
+++ b/test/wkok/openai_clojure/sse_test.clj
@@ -33,4 +33,17 @@
             (is (= (first test-data)
                    (a/<!! events)))
             (is (= (second test-data)
+                   (a/<!! events))))))))
+
+  (testing "support multibytes"
+    (let [test-data [{:text "こんにちは"} {:text "你好"}]
+          test-events (generate-events test-data)]
+      (with-open [output-stream (PipedOutputStream.)
+                  input-stream (PipedInputStream. output-stream)]
+        (with-redefs [http/request (constantly {:body input-stream})]
+          (let [events (sse/sse-events {})]
+            (stream-string output-stream test-events)
+            (is (= (first test-data)
+                   (a/<!! events)))
+            (is (= (second test-data)
                    (a/<!! events)))))))))


### PR DESCRIPTION
## Problem

Multibyte characters get garbled in the response from the OpenAI API

## Cause
In `wkok.openai-clojure.sse/sse-events`, data is slurped from `byte-array` obtained from `event-stream`.
https://github.com/wkok/openai-clojure/blob/d9877fbeb0e04d8b108876f4d8ebf132d2be81b6/src/wkok/openai_clojure/sse.clj#L56

However, when `byte-array` is in an incomplete state, the correct string cannot be retrieved and ends up being garbled.

## Solution
By holding the byte sequence as it is, rather than as a string, until it matches the `event-mask`, we have ensured that a string is not extracted from an incomplete byte sequence.