### PR TITLE
Added ability to override the OpenAI API endpoint

### DIFF
--- a/doc/01-usage-openai.md
+++ b/doc/01-usage-openai.md
@@ -30,15 +30,20 @@ An API key can be generated in your [OpenAI account](https://platform.openai.com
 
 *Optional* - If your OpenAI account uses multiple organizations, set the environment variable `OPENAI_ORGANIZATION` to the one used for your app.
 
+### Endpoint
+
+It is not necessary to specify the endpoint url if using the default OpenAI service. If you do need to point to a different endpoint set the environment variable `OPENAI_API_ENDPOINT` for example: *https://myendpoint.my-openai.com*
+
 ### Options
 
-Alternatively the `api-key` and/or `organization` can be passed in the `options` argument of each api function
+Alternatively the `api-key` and/or `organization` and/or `api-endpoint` can be passed in the `options` argument of each api function
 
 ```
 (api/create-completion {:model "text-davinci-003"
                         :prompt "Say this is a test"}
                        {:api-key "xxxxx"
-                        :organization "abcd"})
+                        :organization "abcd"
+                        :api-endpoint "https://myendpoint.my-openai.com"})
 ```
 
 ## Quickstart

--- a/test/wkok/openai_clojure/openai_test.clj
+++ b/test/wkok/openai_clojure/openai_test.clj
@@ -42,3 +42,18 @@
                                                                               :organization "my-company"}}})
                  :request
                  :headers))))))
+
+(deftest override-api-endpoint-test
+  (let [base-url "https://api.openai.com/v2"
+        override-api-endpoint-fn (-> base-url openai/override-api-endpoint :enter)]
+    (testing "api endpoint gets correctly overridden"
+
+      (let [api-endpoint "https://myendpoint.my-openai.com/v2"
+            path "/some/chat/prompt"
+            test-fn (fn [url]
+                      (is (= (str api-endpoint path)
+                             (-> (override-api-endpoint-fn {:request {:url url}
+                                                            :params {:wkok.openai-clojure.core/options {:api-endpoint api-endpoint}}})
+                                 :request
+                                 :url))))]
+        (test-fn (str base-url "/some/chat/prompt"))))))


### PR DESCRIPTION
Discussion refers: https://clojurians.slack.com/archives/C054XC5JVDZ/p1693981662110889

Sometimes it might be needed to override the `:api-endpoint` for the OpenAI API

This PR allows that by either specifying it in the `options` map for each api call:

```clojure
(create-completion {:model "text-davinci-003"
                    :prompt "Say this is a test"}
                   {:api-endpoint "https://my-new-endpoint.com"})
```

or once off as an environment variable:

```bash
export OPENAI_API_ENDPOINT="https://my-new-endpoint.com"
```