### PR TITLE
Add support for Speech API

### DIFF
--- a/src/wkok/openai_clojure/api.clj
+++ b/src/wkok/openai_clojure/api.clj
@@ -222,6 +222,23 @@
   ([params options]
    (core/response-for :create-translation params options)))
 
+(defn create-speech
+  "Creates audio from text.
+
+  Example:
+  ```
+  (create-speech {:model \"tts-1\"
+                  :input \"Hello! Nice to meet you!.\"
+                  :voice \"alloy\"
+                  :response_format \"mp3\"})
+  ```
+  Also see the [OpenAI documentation](https://platform.openai.com/docs/api-reference/audio/createSpeech)
+  "
+  ([params]
+   (create-speech params nil))
+  ([params options]
+   (core/response-for :create-speech params options)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Files

--- a/test/wkok/openai_clojure/api_test.clj
+++ b/test/wkok/openai_clojure/api_test.clj
@@ -142,6 +142,11 @@
        (is (= :success
               (api/create-translation {:file  (io/file "path/to/file/german.m4a")
                                        :model "whisper-1"})))
+       (is (= :success
+              (api/create-speech {:model "tts-1"
+                                  :input "Hey there! Nice to meet you!"
+                                  :voice "alloy"
+                                  :response_format "mp3"})))
 
        (is (= :success
               (api/list-files)))


### PR DESCRIPTION
Added support for basic Speech API 

Support streaming API is done by default like [here](https://platform.openai.com/docs/guides/text-to-speech/streaming-real-time-audio) using [Chunk Transfer Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding)
![image](https://github.com/wkok/openai-clojure/assets/16940343/e98e1a6a-6b75-4456-a134-a7dece254674)
with http/1.1