### PR TITLE
Added ability to pass http client request options like the timeout

### DIFF
--- a/doc/01-usage-openai.md
+++ b/doc/01-usage-openai.md
@@ -82,6 +82,24 @@ Result:
    :index 0}]}
 ```
 
+## Advanced configuration
+
+### Request options
+
+Request options may be set on the underlying hato http client by adding a `:request` map to `:options` for example setting the request timeout:
+
+```clojure
+(api/create-chat-completion {:model "gpt-3.5-turbo"
+                             :messages [{:role "system" :content "You are a helpful assistant."}
+                                        {:role "user" :content "Who won the world series in 2020?"}
+                                        {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                        {:role "user" :content "Where was it played?"}]}
+
+                            {:request {:timeout 60000}})    ;; <== This
+```
+
+Any of these [supported request options](https://github.com/gnarroway/hato#request-options) may be passed.
+
 ## Supported OpenAI APIs
 
 ### Models

--- a/doc/02-usage-azure.md
+++ b/doc/02-usage-azure.md
@@ -79,6 +79,25 @@ Result:
    :index 0}]}
 ```
 
+## Advanced configuration
+
+### Request options
+
+Request options may be set on the underlying hato http client by adding a `:request` map to `:options` for example setting the request timeout:
+
+```clojure
+(api/create-chat-completion {:model "gpt-3.5-turbo"
+                             :messages [{:role "system" :content "You are a helpful assistant."}
+                                        {:role "user" :content "Who won the world series in 2020?"}
+                                        {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                        {:role "user" :content "Where was it played?"}]}
+
+                            {:request {:timeout 60000}})    ;; <== This
+```
+
+Any of these [supported request options](https://github.com/gnarroway/hato#request-options) may be passed.
+
+
 ## Supported Azure OpenAI APIs
 
 ### Completions

--- a/src/wkok/openai_clojure/azure.clj
+++ b/src/wkok/openai_clojure/azure.clj
@@ -5,6 +5,7 @@
    [clojure.string :as s]
    [martian.core :as martian]
    [martian.hato :as martian-http]
+   [wkok.openai-clojure.interceptors :as openai-interceptors]
    [wkok.openai-clojure.sse :as sse]))
 
 (def add-authentication-header
@@ -48,13 +49,16 @@
 (def m
   (delay
     (patch-handler
-     (martian/bootstrap-openapi "/openai"
-                                (load-openai-spec)
-                                (update
-                                 martian-http/default-opts
-                                 :interceptors
-                                 #(-> (remove (comp #{martian-http/perform-request}) %)
-                                      (concat [add-authentication-header override-api-endpoint sse/perform-sse-capable-request])))))))
+      (martian/bootstrap-openapi "/openai"
+                                 (load-openai-spec)
+                                 (update
+                                   martian-http/default-opts
+                                   :interceptors
+                                   #(-> (remove (comp #{martian-http/perform-request}) %)
+                                        (concat [add-authentication-header
+                                                 openai-interceptors/set-request-options
+                                                 override-api-endpoint
+                                                 sse/perform-sse-capable-request])))))))
 
 (defn patch-params [params]
   {:api-version "2023-05-15"

--- a/src/wkok/openai_clojure/interceptors.clj
+++ b/src/wkok/openai_clojure/interceptors.clj
@@ -1,0 +1,7 @@
+(ns wkok.openai-clojure.interceptors)
+
+(def set-request-options
+  {:name ::method
+   :enter (fn [{{{request :request} :wkok.openai-clojure.core/options} :params
+                :as ctx}]
+            (update ctx :request merge request))})

--- a/src/wkok/openai_clojure/openai.clj
+++ b/src/wkok/openai_clojure/openai.clj
@@ -6,10 +6,10 @@
     [martian.openapi :as openapi]
     [martian.yaml :as yaml]
     [wkok.openai-clojure.sse :as sse]
+    [wkok.openai-clojure.interceptors :as openai-interceptors]
     [martian.encoders :as encoders]
     [martian.interceptors :as interceptors]
-    [schema.core :as s]
-    [clojure.string :as string]))
+    [schema.core :as s]))
 
 (def add-headers
   {:name  ::add-headers
@@ -87,6 +87,7 @@
                                      (-> (remove #(#{:martian.hato/perform-request} (:name %))
                                                  interceptors)
                                          (concat [add-headers
+                                                  openai-interceptors/set-request-options
                                                   (override-api-endpoint base-url)
                                                   (interceptors/encode-body encoders)
                                                   multipart-form-data

--- a/test/wkok/openai_clojure/api_test.clj
+++ b/test/wkok/openai_clojure/api_test.clj
@@ -386,3 +386,18 @@
                       :multipart)]
     (is (some #(#{"file"} (:name %)) multipart))
     (is (some #(#{"model"} (:name %)) multipart))))
+
+
+(deftest request-options-test
+  (testing "Request options are set on the http client"
+    (let [request (martian/request-for @openai/m
+                                       :create-chat-completion
+                                       {:model    "gpt-3.5-turbo"
+                                        :messages [{:role "system" :content "You are a helpful assistant."}
+                                                   {:role "user" :content "Who won the world series in 2020?"}
+                                                   {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                                   {:role "user" :content "Where was it played?"}]
+                                        :wkok.openai-clojure.core/options {:request {:timeout 1000}}})]
+
+      (is (= 1000
+             (:timeout request))))))


### PR DESCRIPTION
Closes #44 

Sample usage:

```clojure
(api/create-chat-completion {:model "gpt-3.5-turbo"
                             :messages [{:role "system" :content "You are a helpful assistant."}
                                        {:role "user" :content "Who won the world series in 2020?"}
                                        {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
                                        {:role "user" :content "Where was it played?"}]}

                            {:request {:timeout 60000}})    ;; <== This

```