### PR TITLE
Fixed warning for no matching content type

### DIFF
--- a/src/wkok/openai_clojure/interceptors.clj
+++ b/src/wkok/openai_clojure/interceptors.clj
@@ -1,7 +1,7 @@
 (ns wkok.openai-clojure.interceptors)
 
 (def set-request-options
-  {:name ::method
+  {:name ::set-request-options
    :enter (fn [{{{request :request} :wkok.openai-clojure.core/options} :params
                 :as ctx}]
             (update ctx :request merge request))})


### PR DESCRIPTION
Fixes #42 

The `create-speech` api introduced an `application/octet-stream` content type for the response that we need to ignore during spec validation.