### PR TITLE
Fix reflection warning

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,5 @@
   :test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
                       io.github.cognitect-labs/test-runner
-                      {:git/tag "v0.5.0" :git/sha "48c3c67"}}}}}
+                      {:git/tag "v0.5.0" :git/sha "48c3c67"}}
+         :main-opts ["-e" "(set! *warn-on-reflection* true)"]}}}

--- a/src/wkok/openai_clojure/sse.clj
+++ b/src/wkok/openai_clojure/sse.clj
@@ -85,7 +85,7 @@
                   data (slurp (byte-array next-byte-coll))]
               (if-let [es (not-empty (re-seq event-mask data))]
                 (if (every? true? (map #(a/>!! events %) es))
-                  (recur (drop (apply + (map #(count (.getBytes %)) es))
+                  (recur (drop (apply + (map #(count (.getBytes ^String %)) es))
                                next-byte-coll))
 
                   ;; Output stream closed, exiting read-loop


### PR DESCRIPTION
I added a `(set! *warn-on-reflection* true)` in the deps.edn test profile.

There is one remaining warning in a dependency of martian:

> Reflection warning, tripod/context.cljc:12:52 - reference to field getMessage can't be resolved.

Pull request by borkdude tackling this problem: https://github.com/frankiesardo/tripod/pull/8

Since the PR is still open, he solved it using a patch: https://github.com/oliyh/martian/blob/732be670cd26d2a401b3830867589e33817e7fec/core/src/martian/core.cljc#L13


Test results:
```
 openai-clojure git:(main) ✗ clojure -M:test -m cognitect.test-runner
true

Running tests in #{"test"}
Reflection warning, tripod/context.cljc:12:52 - reference to field getMessage can't be resolved.

Testing wkok.openai-clojure.api-integration-test

Testing wkok.openai-clojure.api-test

WARNING - passing impl as first argument is deprecated, use options instead


WARNING - passing impl as first argument is deprecated, use options instead


Testing wkok.openai-clojure.azure-test

Testing wkok.openai-clojure.core-test

WARNING - passing impl as first argument is deprecated, use options instead


WARNING - passing impl as first argument is deprecated, use options instead


Testing wkok.openai-clojure.openai-test

Testing wkok.openai-clojure.sse-test

Ran 16 tests containing 93 assertions.
0 failures, 0 errors.
```
