### PR TITLE
Trace raw request and response

### DIFF
--- a/doc/04-debugging.md
+++ b/doc/04-debugging.md
@@ -1,0 +1,42 @@
+# Debugging
+
+When supplying a `trace` function in `:options` it will be called with the raw maps of the request and response for allowing capturing tracing information like the raw messages sent/received:
+
+```clojure
+(create-chat-completion {:model    "gpt-3.5-turbo"
+                         :messages [{:role "system" :content "You are a helpful assistant."}
+                                    {:role "user" :content "Who won the world series in 2020?"}
+                                    {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                    {:role "user" :content "Where was it played?"}]}
+                        {:trace (fn [request response]
+                                   (println (:body response)))})
+```
+
+Prints:
+
+```json
+{
+  "id": "chatcmpl-8gHB7Il500UxZPChGAZHtklLWTS8T",
+  "object": "chat.completion",
+  "created": 1705086501,
+  "model": "gpt-3.5-turbo-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The 2020 World Series was played at Globe Life Field in Arlington, Texas."
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 53,
+    "completion_tokens": 17,
+    "total_tokens": 70
+  },
+  "system_fingerprint": null
+}
+
+```

--- a/src/wkok/openai_clojure/sse.clj
+++ b/src/wkok/openai_clojure/sse.clj
@@ -105,35 +105,32 @@
     {:status 200
      :body events}))
 
-(defn wrap-logger
-  "Middleware that allows the user to supply a logging-fn that
+(defn wrap-trace
+  "Middleware that allows the user to supply a trace function that
   will receive the raw request & response as arguments.
   See: https://github.com/gnarroway/hato?tab=readme-ov-file#custom-middleware"
-  [logger]
+  [trace]
   (fn [client]
     (fn
       ([req]
        (let [resp (client req)]
-         (logger (or (:body req)
-                     (:url req))
-                 (:body resp))
+         (trace (:body req)
+                (:body resp))
          resp))
       ([req respond raise]
        (client req
-               #(respond (do (logger (or (:body req)
-                                         (:url req))
-                                     (:body %))
+               #(respond (do (trace (:body req)
+                                    (:body %))
                              %))
                raise)))))
-
 
 (def perform-sse-capable-request
   {:name  ::perform-sse-capable-request
    :leave (fn [{:keys [request params] :as ctx}]
-            (let [{{logger :logger} :wkok.openai-clojure.core/options} params]
+            (let [{{trace :trace} :wkok.openai-clojure.core/options} params]
               (assoc ctx :response (if (:stream params)
                                      (sse-request ctx)
                                      (http/request
-                                       (if logger
-                                         (assoc request :middleware (conj hm/default-middleware (wrap-logger logger)))
+                                       (if trace
+                                         (assoc request :middleware (conj hm/default-middleware (wrap-trace trace)))
                                          request))))))})


### PR DESCRIPTION
Closes #49 

This PR ads the ability to supply a `trace` function in `:options` that will be called with the raw maps of the request and response for allowing capturing tracing information for example:

```clojure
(create-chat-completion {:model    "gpt-3.5-turbo"
                         :messages [{:role "system" :content "You are a helpful assistant."}
                                    {:role "user" :content "Who won the world series in 2020?"}
                                    {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
                                    {:role "user" :content "Where was it played?"}]}
                        {:trace (fn [request response]
                                   (println (:body response)))})
```

prints:

```json
{
  "id": "chatcmpl-8gHB7Il500UxZPChGAZHtklLWTS8T",
  "object": "chat.completion",
  "created": 1705086501,
  "model": "gpt-3.5-turbo-0613",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "The 2020 World Series was played at Globe Life Field in Arlington, Texas."
      },
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 53,
    "completion_tokens": 17,
    "total_tokens": 70
  },
  "system_fingerprint": null
}



```