### PR TITLE
Added async support

### DIFF
--- a/doc/05-async.md
+++ b/doc/05-async.md
@@ -1,0 +1,12 @@
+# Async support
+
+When supplying `{:request {:async? true}}` in `:options` the request will be sent asynchronously and immediately return a Future that can be de-referenced to retrieve the result:
+
+```clojure
+@(create-chat-completion {:model    "gpt-3.5-turbo"
+                          :messages [{:role "system" :content "You are a helpful assistant."}
+                                     {:role "user" :content "Who won the world series in 2020?"}
+                                     {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                     {:role "user" :content "Where was it played?"}]}
+                         {:request {:async? true}})
+```

--- a/src/wkok/openai_clojure/core.clj
+++ b/src/wkok/openai_clojure/core.clj
@@ -15,7 +15,7 @@
 
 (defn response-for
   [operation params
-   {:keys [impl]
+   {:keys [impl request]
     :or {impl :openai}
     :as options}]
 
@@ -31,7 +31,10 @@
                            :openai identity
                            :azure azure/patch-params)
 
-          patched-params (patch-parms-fn params)]
+          patched-params (patch-parms-fn params)
 
-      (-> (martian/response-for m operation (assoc patched-params ::options options))
-          :body))))
+          response (martian/response-for m operation (assoc patched-params ::options options))]
+
+      (if (:async? request)
+        response
+        (:body response)))))

--- a/src/wkok/openai_clojure/sse.clj
+++ b/src/wkok/openai_clojure/sse.clj
@@ -170,7 +170,13 @@
 
               (if async?
 
-                ((:leave martian.hato/perform-request-async) ctx')
+                (-> ((:leave martian.hato/perform-request-async) ctx')
+                    (update :response
+                            #(.thenApply
+                               %
+                               (reify java.util.function.Function
+                                 (apply [_ response']
+                                   (:body response'))))))
 
                 (assoc ctx :response (if (:stream params)
                                        (sse-request ctx')

--- a/test/wkok/openai_clojure/api_integration_test.clj
+++ b/test/wkok/openai_clojure/api_integration_test.clj
@@ -10,3 +10,17 @@
                                                            {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
                                                            {:role "user" :content "Where was it played?"}]})
                    :choices))))
+
+
+(deftest create-chat-completion-async
+  (testing "creates a simple chat completion async"
+    (let [result (api/create-chat-completion {:model    "gpt-3.5-turbo"
+                                              :messages [{:role "system" :content "You are a helpful assistant."}
+                                                         {:role "user" :content "Who won the world series in 2020?"}
+                                                         {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
+                                                         {:role "user" :content "Where was it played?"}]}
+                                             {:request {:async? true}})]
+
+      (is (future? result))
+
+      (is (contains? @result :choices)))))


### PR DESCRIPTION
Fixes #52 

Added async support. When passing `:async? true` the result returned to the caller will be a Future that can be de-referenced for example:

```
@(create-chat-completion {:model    "gpt-3.5-turbo"
                          :messages [{:role "system" :content "You are a helpful assistant."}
                                     {:role "user" :content "Who won the world series in 2020?"}
                                     {:role "assistant" :content "The Los Angeles Dodgers won the World Series in 2020."}
                                     {:role "user" :content "Where was it played?"}]}
                         {:request {:async? true}})
```
