### PR TITLE
Make sure sse async channel gets closed.

### DIFF
--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -25,6 +25,8 @@ tags:
     description: Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
   - name: Fine-tuning
     description: Manage fine-tuning jobs to tailor a model to your specific training data.
+  - name: Batch
+    description: Create large batches of API requests to run asynchronously.
   - name: Files
     description: Files are used to upload documents that can be used with features like Assistants and Fine-tuning.
   - name: Images
@@ -32,7 +34,7 @@ tags:
   - name: Models
     description: List and describe the various models available in the API.
   - name: Moderations
-    description: Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+    description: Given a input text, outputs if the model classifies it as potentially harmful.
 paths:
   # Note: When adding an endpoint, make sure you also add it in the `groups` section, in the end of this file,
   # under the appropriate group
@@ -115,7 +117,7 @@ paths:
                 "id": "chatcmpl-123",
                 "object": "chat.completion",
                 "created": 1677652288,
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "system_fingerprint": "fp_44709d6fcb",
                 "choices": [{
                   "index": 0,
@@ -139,14 +141,14 @@ paths:
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer $OPENAI_API_KEY" \
                   -d '{
-                    "model": "gpt-4-vision-preview",
+                    "model": "gpt-4-turbo",
                     "messages": [
                       {
                         "role": "user",
                         "content": [
                           {
                             "type": "text",
-                            "text": "What’s in this image?"
+                            "text": "What'\''s in this image?"
                           },
                           {
                             "type": "image_url",
@@ -165,12 +167,12 @@ paths:
                 client = OpenAI()
 
                 response = client.chat.completions.create(
-                    model="gpt-4-vision-preview",
+                    model="gpt-4-turbo",
                     messages=[
                         {
                             "role": "user",
                             "content": [
-                                {"type": "text", "text": "What’s in this image?"},
+                                {"type": "text", "text": "What's in this image?"},
                                 {
                                     "type": "image_url",
                                     "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
@@ -189,12 +191,12 @@ paths:
 
                 async function main() {
                   const response = await openai.chat.completions.create({
-                    model: "gpt-4-vision-preview",
+                    model: "gpt-4-turbo",
                     messages: [
                       {
                         role: "user",
                         content: [
-                          { type: "text", text: "What’s in this image?" },
+                          { type: "text", text: "What's in this image?" },
                           {
                             type: "image_url",
                             image_url:
@@ -212,13 +214,13 @@ paths:
                 "id": "chatcmpl-123",
                 "object": "chat.completion",
                 "created": 1677652288,
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "system_fingerprint": "fp_44709d6fcb",
                 "choices": [{
                   "index": 0,
                   "message": {
                     "role": "assistant",
-                    "content": "\n\nHello there, how may I assist you today?",
+                    "content": "\n\nThis image shows a wooden boardwalk extending through a lush green marshland.",
                   },
                   "logprobs": null,
                   "finish_reason": "stop"
@@ -287,19 +289,13 @@ paths:
 
                 main();
             response: &chat_completion_chunk_example |
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0125", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
 
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
-
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0125", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
 
               ....
 
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}]}
-
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
-
-              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0613", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-3.5-turbo-0125", "system_fingerprint": "fp_44709d6fcb", "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
           - title: Functions
             request:
               curl: |
@@ -307,11 +303,11 @@ paths:
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -d '{
-                  "model": "gpt-3.5-turbo",
+                  "model": "gpt-4-turbo",
                   "messages": [
                     {
                       "role": "user",
-                      "content": "What is the weather like in Boston?"
+                      "content": "What'\''s the weather like in Boston today?"
                     }
                   ],
                   "tools": [
@@ -401,7 +397,7 @@ paths:
                   ];
 
                   const response = await openai.chat.completions.create({
-                    model: "gpt-3.5-turbo",
+                    model: "gpt-4-turbo",
                     messages: messages,
                     tools: tools,
                     tool_choice: "auto",
@@ -416,7 +412,7 @@ paths:
                 "id": "chatcmpl-abc123",
                 "object": "chat.completion",
                 "created": 1699896916,
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "choices": [
                   {
                     "index": 0,
@@ -498,7 +494,7 @@ paths:
                 "id": "chatcmpl-123",
                 "object": "chat.completion",
                 "created": 1702685778,
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "choices": [
                   {
                     "index": 0,
@@ -1201,47 +1197,174 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateTranscriptionResponse"
+                oneOf:
+                  - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
+                  - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
       x-oaiMeta:
         name: Create transcription
         group: audio
-        returns: The transcribed text.
+        returns: The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).
         examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/audio/transcriptions \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: multipart/form-data" \
-                -F file="@/path/to/file/audio.mp3" \
-                -F model="whisper-1"
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F model="whisper-1"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
 
-              audio_file = open("speech.mp3", "rb")
-              transcript = client.audio.transcriptions.create(
-                model="whisper-1",
-                file=audio_file
-              )
-            node: |
-              import fs from "fs";
-              import OpenAI from "openai";
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  model="whisper-1",
+                  file=audio_file
+                )
+              node: |
+                import fs from "fs";
+                import OpenAI from "openai";
 
-              const openai = new OpenAI();
+                const openai = new OpenAI();
 
-              async function main() {
-                const transcription = await openai.audio.transcriptions.create({
-                  file: fs.createReadStream("audio.mp3"),
-                  model: "whisper-1",
-                });
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                  });
 
-                console.log(transcription.text);
+                  console.log(transcription.text);
+                }
+                main();
+            response: &basic_transcription_response_example |
+              {
+                "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
               }
-              main();
-          response: |
-            {
-              "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
-            }
+          - title: Word timestamps
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F "timestamp_granularities[]=word" \
+                  -F model="whisper-1" \
+                  -F response_format="verbose_json"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  file=audio_file,
+                  model="whisper-1",
+                  response_format="verbose_json",
+                  timestamp_granularities=["word"]
+                )
+
+                print(transcript.words)
+              node: |
+                import fs from "fs";
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                    response_format: "verbose_json",
+                    timestamp_granularities: ["word"]
+                  });
+
+                  console.log(transcription.text);
+                }
+                main();
+            response: |
+              {
+                "task": "transcribe",
+                "language": "english",
+                "duration": 8.470000267028809,
+                "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                "words": [
+                  {
+                    "word": "The",
+                    "start": 0.0,
+                    "end": 0.23999999463558197
+                  },
+                  ...
+                  {
+                    "word": "volleyball",
+                    "start": 7.400000095367432,
+                    "end": 7.900000095367432
+                  }
+                ]
+              }
+          - title: Segment timestamps
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F "timestamp_granularities[]=segment" \
+                  -F model="whisper-1" \
+                  -F response_format="verbose_json"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  file=audio_file,
+                  model="whisper-1",
+                  response_format="verbose_json",
+                  timestamp_granularities=["segment"]
+                )
+
+                print(transcript.words)
+              node: |
+                import fs from "fs";
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                    response_format: "verbose_json",
+                    timestamp_granularities: ["segment"]
+                  });
+
+                  console.log(transcription.text);
+                }
+                main();
+            response: &verbose_transcription_response_example |
+              {
+                "task": "transcribe",
+                "language": "english",
+                "duration": 8.470000267028809,
+                "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                "segments": [
+                  {
+                    "id": 0,
+                    "seek": 0,
+                    "start": 0.0,
+                    "end": 3.319999933242798,
+                    "text": " The beach was a popular spot on a hot summer day.",
+                    "tokens": [
+                      50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530
+                    ],
+                    "temperature": 0.0,
+                    "avg_logprob": -0.2860786020755768,
+                    "compression_ratio": 1.2363636493682861,
+                    "no_speech_prob": 0.00985979475080967
+                  },
+                  ...
+                ]
+              }
   /audio/translations:
     post:
       operationId: createTranslation
@@ -1260,7 +1383,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateTranslationResponse"
+                oneOf:
+                  - $ref: "#/components/schemas/CreateTranslationResponseJson"
+                  - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
       x-oaiMeta:
         name: Create translation
         group: audio
@@ -1377,9 +1502,13 @@ paths:
       tags:
         - Files
       summary: |
-        Upload a file that can be used across various endpoints. The size of all the files uploaded by one organization can be up to 100 GB.
+        Upload a file that can be used across various endpoints. Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB.
 
-        The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See the [Assistants Tools guide](/docs/assistants/tools) to learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
+        The Assistants API supports files up to 2 million tokens and of specific file types. See the [Assistants Tools guide](/docs/assistants/tools) for details.
+
+        The Fine-tuning API only supports `.jsonl` files.
+
+        The Batch API only supports `.jsonl` files up to 100 MB in size.
 
         Please [contact us](https://help.openai.com/) if you need to increase these storage limits.
       requestBody:
@@ -1562,10 +1691,8 @@ paths:
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                type: string
+          # content:
+          #   application/octet-stream: {}
       x-oaiMeta:
         name: Retrieve file content
         group: files
@@ -1579,14 +1706,14 @@ paths:
               from openai import OpenAI
               client = OpenAI()
 
-              content = client.files.retrieve_content("file-abc123")
+              content = client.files.content("file-abc123")
             node.js: |
               import OpenAI from "openai";
 
               const openai = new OpenAI();
 
               async function main() {
-                const file = await openai.files.retrieveContent("file-abc123");
+                const file = await openai.files.content("file-abc123");
 
                 console.log(file);
               }
@@ -1658,7 +1785,7 @@ paths:
               {
                 "object": "fine_tuning.job",
                 "id": "ftjob-abc123",
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "created_at": 1614807352,
                 "fine_tuned_model": null,
                 "organization_id": "org-123",
@@ -1711,7 +1838,7 @@ paths:
               {
                 "object": "fine_tuning.job",
                 "id": "ftjob-abc123",
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "created_at": 1614807352,
                 "fine_tuned_model": null,
                 "organization_id": "org-123",
@@ -1760,7 +1887,7 @@ paths:
               {
                 "object": "fine_tuning.job",
                 "id": "ftjob-abc123",
-                "model": "gpt-3.5-turbo-0613",
+                "model": "gpt-3.5-turbo-0125",
                 "created_at": 1614807352,
                 "fine_tuned_model": null,
                 "organization_id": "org-123",
@@ -1768,6 +1895,52 @@ paths:
                 "status": "queued",
                 "validation_file": "file-abc123",
                 "training_file": "file-abc123",
+              }
+          - title: W&B Integration
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "validation_file": "file-abc123",
+                    "model": "gpt-3.5-turbo",
+                    "integrations": [
+                      {
+                        "type": "wandb",
+                        "wandb": {
+                          "project": "my-wandb-project",
+                          "name": "ft-run-display-name"
+                          "tags": [
+                            "first-experiment", "v2"
+                          ]
+                        }
+                      }
+                    ]
+                  }'
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-3.5-turbo-0125",
+                "created_at": 1614807352,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": "file-abc123",
+                "training_file": "file-abc123",
+                "integrations": [
+                  {
+                    "type": "wandb",
+                    "wandb": {
+                      "project": "my-wandb-project",
+                      "entity": None,
+                      "run_id": "ftjob-abc123"
+                    }
+                  }
+                ]
               }
     get:
       operationId: listPaginatedFineTuningJobs
@@ -1909,8 +2082,13 @@ paths:
               "training_file": "file-abc123",
               "hyperparameters": {
                   "n_epochs": 4,
+                  "batch_size": 1,
+                  "learning_rate_multiplier": 1.0
               },
-              "trained_tokens": 5768
+              "trained_tokens": 5768,
+              "integrations": [],
+              "seed": 0,
+              "estimated_finish": 0
             }
   /fine_tuning/jobs/{fine_tuning_job_id}/events:
     get:
@@ -2056,7 +2234,7 @@ paths:
             {
               "object": "fine_tuning.job",
               "id": "ftjob-abc123",
-              "model": "gpt-3.5-turbo-0613",
+              "model": "gpt-3.5-turbo-0125",
               "created_at": 1689376978,
               "fine_tuned_model": null,
               "organization_id": "org-123",
@@ -2067,6 +2245,84 @@ paths:
               "status": "cancelled",
               "validation_file": "file-abc123",
               "training_file": "file-abc123"
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
+    get:
+      operationId: listFineTuningJobCheckpoints
+      tags:
+        - Fine-tuning
+      summary: |
+        List checkpoints for a fine-tuning job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to get checkpoints for.
+        - name: after
+          in: query
+          description: Identifier for the last checkpoint ID from the previous pagination request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of checkpoints to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+      x-oaiMeta:
+        name: List fine-tuning checkpoints
+        group: fine-tuning
+        returns: A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/checkpoints \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+          response: |
+            {
+              "object": "list"
+              "data": [
+                {
+                  "object": "fine_tuning.job.checkpoint",
+                  "id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                  "created_at": 1519129973,
+                  "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:96olL566:ckpt-step-2000",
+                  "metrics": {
+                    "full_valid_loss": 0.134,
+                    "full_valid_mean_token_accuracy": 0.874
+                  },
+                  "fine_tuning_job_id": "ftjob-abc123",
+                  "step_number": 2000,
+                },
+                {
+                  "object": "fine_tuning.job.checkpoint",
+                  "id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                  "created_at": 1519129833,
+                  "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom-suffix:7q8mpxmy:ckpt-step-1000",
+                  "metrics": {
+                    "full_valid_loss": 0.167,
+                    "full_valid_mean_token_accuracy": 0.781
+                  },
+                  "fine_tuning_job_id": "ftjob-abc123",
+                  "step_number": 1000,
+                },
+              ],
+              "first_id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+              "last_id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+              "has_more": true
             }
 
   /models:
@@ -2176,7 +2432,7 @@ paths:
               const openai = new OpenAI();
 
               async function main() {
-                const model = await openai.models.retrieve("gpt-3.5-turbo");
+                const model = await openai.models.retrieve("VAR_model_id");
 
                 console.log(model);
               }
@@ -2247,7 +2503,7 @@ paths:
       operationId: createModeration
       tags:
         - Moderations
-      summary: Classifies if text violates OpenAI's Content Policy
+      summary: Classifies if text is potentially harmful.
       requestBody:
         required: true
         content:
@@ -2278,7 +2534,8 @@ paths:
               from openai import OpenAI
               client = OpenAI()
 
-              client.moderations.create(input="I want to kill them.")
+              moderation = client.moderations.create(input="I want to kill them.")
+              print(moderation)
             node.js: |
               import OpenAI from "openai";
 
@@ -2380,7 +2637,7 @@ paths:
               curl "https://api.openai.com/v1/assistants?order=desc&limit=20" \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -2415,11 +2672,14 @@ paths:
                   "created_at": 1698982736,
                   "name": "Coding Tutor",
                   "description": null,
-                  "model": "gpt-4",
+                  "model": "gpt-4-turbo",
                   "instructions": "You are a helpful assistant designed to make me better at coding!",
                   "tools": [],
-                  "file_ids": [],
-                  "metadata": {}
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
                 },
                 {
                   "id": "asst_abc456",
@@ -2427,11 +2687,14 @@ paths:
                   "created_at": 1698982718,
                   "name": "My Assistant",
                   "description": null,
-                  "model": "gpt-4",
+                  "model": "gpt-4-turbo",
                   "instructions": "You are a helpful assistant designed to make me better at coding!",
                   "tools": [],
-                  "file_ids": [],
-                  "metadata": {}
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
                 },
                 {
                   "id": "asst_abc789",
@@ -2439,11 +2702,14 @@ paths:
                   "created_at": 1698982643,
                   "name": null,
                   "description": null,
-                  "model": "gpt-4",
+                  "model": "gpt-4-turbo",
                   "instructions": null,
                   "tools": [],
-                  "file_ids": [],
-                  "metadata": {}
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
                 }
               ],
               "first_id": "asst_abc123",
@@ -2480,12 +2746,12 @@ paths:
                 curl "https://api.openai.com/v1/assistants" \
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer $OPENAI_API_KEY" \
-                  -H "OpenAI-Beta: assistants=v1" \
+                  -H "OpenAI-Beta: assistants=v2" \
                   -d '{
                     "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
                     "name": "Math Tutor",
                     "tools": [{"type": "code_interpreter"}],
-                    "model": "gpt-4"
+                    "model": "gpt-4-turbo"
                   }'
 
               python: |
@@ -2496,7 +2762,7 @@ paths:
                     instructions="You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
                     name="Math Tutor",
                     tools=[{"type": "code_interpreter"}],
-                    model="gpt-4",
+                    model="gpt-4-turbo",
                 )
                 print(my_assistant)
               node.js: |-
@@ -2510,7 +2776,7 @@ paths:
                       "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
                     name: "Math Tutor",
                     tools: [{ type: "code_interpreter" }],
-                    model: "gpt-4",
+                    model: "gpt-4-turbo",
                   });
 
                   console.log(myAssistant);
@@ -2524,15 +2790,17 @@ paths:
                 "created_at": 1698984975,
                 "name": "Math Tutor",
                 "description": null,
-                "model": "gpt-4",
+                "model": "gpt-4-turbo",
                 "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
                 "tools": [
                   {
                     "type": "code_interpreter"
                   }
                 ],
-                "file_ids": [],
-                "metadata": {}
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
               }
           - title: Files
             request:
@@ -2540,12 +2808,12 @@ paths:
                 curl https://api.openai.com/v1/assistants \
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer $OPENAI_API_KEY" \
-                  -H "OpenAI-Beta: assistants=v1" \
+                  -H "OpenAI-Beta: assistants=v2" \
                   -d '{
                     "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
-                    "tools": [{"type": "retrieval"}],
-                    "model": "gpt-4",
-                    "file_ids": ["file-abc123"]
+                    "tools": [{"type": "file_search"}],
+                    "tool_resources": {"file_search": {"vector_store_ids": ["vs_123"]}},
+                    "model": "gpt-4-turbo"
                   }'
               python: |
                 from openai import OpenAI
@@ -2554,9 +2822,9 @@ paths:
                 my_assistant = client.beta.assistants.create(
                     instructions="You are an HR bot, and you have access to files to answer employee questions about company policies.",
                     name="HR Helper",
-                    tools=[{"type": "retrieval"}],
-                    model="gpt-4",
-                    file_ids=["file-abc123"],
+                    tools=[{"type": "file_search"}],
+                    tool_resources={"file_search": {"vector_store_ids": ["vs_123"]}},
+                    model="gpt-4-turbo"
                 )
                 print(my_assistant)
               node.js: |-
@@ -2569,9 +2837,13 @@ paths:
                     instructions:
                       "You are an HR bot, and you have access to files to answer employee questions about company policies.",
                     name: "HR Helper",
-                    tools: [{ type: "retrieval" }],
-                    model: "gpt-4",
-                    file_ids: ["file-abc123"],
+                    tools: [{ type: "file_search" }],
+                    tool_resources: {
+                      file_search: {
+                        vector_store_ids: ["vs_123"]
+                      }
+                    },
+                    model: "gpt-4-turbo"
                   });
 
                   console.log(myAssistant);
@@ -2585,17 +2857,22 @@ paths:
                 "created_at": 1699009403,
                 "name": "HR Helper",
                 "description": null,
-                "model": "gpt-4",
+                "model": "gpt-4-turbo",
                 "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
                 "tools": [
                   {
-                    "type": "retrieval"
+                    "type": "file_search"
                   }
                 ],
-                "file_ids": [
-                  "file-abc123"
-                ],
-                "metadata": {}
+                "tool_resources": {
+                  "file_search": {
+                    "vector_store_ids": ["vs_123"]
+                  }
+                },
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
               }
 
   /assistants/{assistant_id}:
@@ -2629,7 +2906,7 @@ paths:
               curl https://api.openai.com/v1/assistants/asst_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -2657,17 +2934,17 @@ paths:
               "created_at": 1699009709,
               "name": "HR Helper",
               "description": null,
-              "model": "gpt-4",
+              "model": "gpt-4-turbo",
               "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
               "tools": [
                 {
-                  "type": "retrieval"
+                  "type": "file_search"
                 }
               ],
-              "file_ids": [
-                "file-abc123"
-              ],
-              "metadata": {}
+              "metadata": {},
+              "top_p": 1.0,
+              "temperature": 1.0,
+              "response_format": "auto"
             }
     post:
       operationId: modifyAssistant
@@ -2705,12 +2982,11 @@ paths:
               curl https://api.openai.com/v1/assistants/asst_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                     "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
-                    "tools": [{"type": "retrieval"}],
-                    "model": "gpt-4",
-                    "file_ids": ["file-abc123", "file-abc456"]
+                    "tools": [{"type": "file_search"}],
+                    "model": "gpt-4-turbo"
                   }'
             python: |
               from openai import OpenAI
@@ -2720,9 +2996,8 @@ paths:
                 "asst_abc123",
                 instructions="You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
                 name="HR Helper",
-                tools=[{"type": "retrieval"}],
-                model="gpt-4",
-                file_ids=["file-abc123", "file-abc456"],
+                tools=[{"type": "file_search"}],
+                model="gpt-4-turbo"
               )
 
               print(my_updated_assistant)
@@ -2738,12 +3013,8 @@ paths:
                     instructions:
                       "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
                     name: "HR Helper",
-                    tools: [{ type: "retrieval" }],
-                    model: "gpt-4",
-                    file_ids: [
-                      "file-abc123",
-                      "file-abc456",
-                    ],
+                    tools: [{ type: "file_search" }],
+                    model: "gpt-4-turbo"
                   }
                 );
 
@@ -2753,23 +3024,27 @@ paths:
               main();
           response: |
             {
-              "id": "asst_abc123",
+              "id": "asst_123",
               "object": "assistant",
               "created_at": 1699009709,
               "name": "HR Helper",
               "description": null,
-              "model": "gpt-4",
+              "model": "gpt-4-turbo",
               "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
               "tools": [
                 {
-                  "type": "retrieval"
+                  "type": "file_search"
                 }
               ],
-              "file_ids": [
-                "file-abc123",
-                "file-abc456"
-              ],
-              "metadata": {}
+              "tool_resources": {
+                "file_search": {
+                  "vector_store_ids": []
+                }
+              },
+              "metadata": {},
+              "top_p": 1.0,
+              "temperature": 1.0,
+              "response_format": "auto"
             }
     delete:
       operationId: deleteAssistant
@@ -2801,7 +3076,7 @@ paths:
               curl https://api.openai.com/v1/assistants/asst_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -X DELETE
             python: |
               from openai import OpenAI
@@ -2857,7 +3132,7 @@ paths:
                 curl https://api.openai.com/v1/threads \
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer $OPENAI_API_KEY" \
-                  -H "OpenAI-Beta: assistants=v1" \
+                  -H "OpenAI-Beta: assistants=v2" \
                   -d ''
               python: |
                 from openai import OpenAI
@@ -2882,7 +3157,8 @@ paths:
                 "id": "thread_abc123",
                 "object": "thread",
                 "created_at": 1699012949,
-                "metadata": {}
+                "metadata": {},
+                "tool_resources": {}
               }
           - title: Messages
             request:
@@ -2890,12 +3166,11 @@ paths:
                 curl https://api.openai.com/v1/threads \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                     "messages": [{
                       "role": "user",
-                      "content": "Hello, what is AI?",
-                      "file_ids": ["file-abc123"]
+                      "content": "Hello, what is AI?"
                     }, {
                       "role": "user",
                       "content": "How does AI work? Explain it in simple terms."
@@ -2909,8 +3184,7 @@ paths:
                   messages=[
                     {
                       "role": "user",
-                      "content": "Hello, what is AI?",
-                      "file_ids": ["file-abc123"],
+                      "content": "Hello, what is AI?"
                     },
                     {
                       "role": "user",
@@ -2930,8 +3204,7 @@ paths:
                     messages: [
                       {
                         role: "user",
-                        content: "Hello, what is AI?",
-                        file_ids: ["file-abc123"],
+                        content: "Hello, what is AI?"
                       },
                       {
                         role: "user",
@@ -2946,10 +3219,11 @@ paths:
                 main();
             response: |
               {
-                id: 'thread_abc123',
-                object: 'thread',
-                created_at: 1699014083,
-                metadata: {}
+                "id": "thread_abc123",
+                "object": "thread",
+                "created_at": 1699014083,
+                "metadata": {},
+                "tool_resources": {}
               }
 
   /threads/{thread_id}:
@@ -2983,7 +3257,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -3009,7 +3283,12 @@ paths:
               "id": "thread_abc123",
               "object": "thread",
               "created_at": 1699014083,
-              "metadata": {}
+              "metadata": {},
+              "tool_resources": {
+                "code_interpreter": {
+                  "file_ids": []
+                }
+              }
             }
     post:
       operationId: modifyThread
@@ -3047,7 +3326,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                     "metadata": {
                       "modified": "true",
@@ -3091,7 +3370,8 @@ paths:
               "metadata": {
                 "modified": "true",
                 "user": "abc123"
-              }
+              },
+              "tool_resources": {}
             }
     delete:
       operationId: deleteThread
@@ -3123,7 +3403,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -X DELETE
             python: |
               from openai import OpenAI
@@ -3186,6 +3466,12 @@ paths:
           description: *pagination_before_param_description
           schema:
             type: string
+        - name: run_id
+          in: query
+          description: |
+            Filter messages by the run ID that generated them.
+          schema:
+            type: string
       responses:
         "200":
           description: OK
@@ -3204,7 +3490,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/messages \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -3233,7 +3519,9 @@ paths:
                   "id": "msg_abc123",
                   "object": "thread.message",
                   "created_at": 1699016383,
+                  "assistant_id": null,
                   "thread_id": "thread_abc123",
+                  "run_id": null,
                   "role": "user",
                   "content": [
                     {
@@ -3244,16 +3532,16 @@ paths:
                       }
                     }
                   ],
-                  "file_ids": [],
-                  "assistant_id": null,
-                  "run_id": null,
+                  "attachments": [],
                   "metadata": {}
                 },
                 {
                   "id": "msg_abc456",
                   "object": "thread.message",
                   "created_at": 1699016383,
+                  "assistant_id": null,
                   "thread_id": "thread_abc123",
+                  "run_id": null,
                   "role": "user",
                   "content": [
                     {
@@ -3264,11 +3552,7 @@ paths:
                       }
                     }
                   ],
-                  "file_ids": [
-                    "file-abc123"
-                  ],
-                  "assistant_id": null,
-                  "run_id": null,
+                  "attachments": [],
                   "metadata": {}
                 }
               ],
@@ -3312,7 +3596,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/messages \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                     "role": "user",
                     "content": "How does AI work? Explain it in simple terms."
@@ -3346,8 +3630,10 @@ paths:
             {
               "id": "msg_abc123",
               "object": "thread.message",
-              "created_at": 1699017614,
+              "created_at": 1713226573,
+              "assistant_id": null,
               "thread_id": "thread_abc123",
+              "run_id": null,
               "role": "user",
               "content": [
                 {
@@ -3358,9 +3644,7 @@ paths:
                   }
                 }
               ],
-              "file_ids": [],
-              "assistant_id": null,
-              "run_id": null,
+              "attachments": [],
               "metadata": {}
             }
 
@@ -3401,7 +3685,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -3431,7 +3715,9 @@ paths:
               "id": "msg_abc123",
               "object": "thread.message",
               "created_at": 1699017614,
+              "assistant_id": null,
               "thread_id": "thread_abc123",
+              "run_id": null,
               "role": "user",
               "content": [
                 {
@@ -3442,9 +3728,7 @@ paths:
                   }
                 }
               ],
-              "file_ids": [],
-              "assistant_id": null,
-              "run_id": null,
+              "attachments": [],
               "metadata": {}
             }
     post:
@@ -3489,7 +3773,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                     "metadata": {
                       "modified": "true",
@@ -3530,7 +3814,9 @@ paths:
               "id": "msg_abc123",
               "object": "thread.message",
               "created_at": 1699017614,
+              "assistant_id": null,
               "thread_id": "thread_abc123",
+              "run_id": null,
               "role": "user",
               "content": [
                 {
@@ -3542,13 +3828,77 @@ paths:
                 }
               ],
               "file_ids": [],
-              "assistant_id": null,
-              "run_id": null,
               "metadata": {
                 "modified": "true",
                 "user": "abc123"
               }
             }
+    delete:
+      operationId: deleteMessage
+      tags:
+        - Assistants
+      summary: Deletes a message.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to which this message belongs.
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the message to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteMessageResponse"
+      x-oaiMeta:
+        name: Delete message
+        group: threads
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl -X DELETE https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_message = client.beta.threads.messages.delete(
+                message_id="msg_abc12",
+                thread_id="thread_abc123",
+              )
+              print(deleted_message)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedMessage = await openai.beta.threads.messages.del(
+                  "thread_abc123",
+                  "msg_abc123"
+                );
+
+                console.log(deletedMessage);
+              }
+          response: |
+            {
+              "id": "msg_abc123",
+              "object": "thread.message.deleted",
+              "deleted": true
+            }
+
 
   /threads/runs:
     post:
@@ -3575,72 +3925,352 @@ paths:
         beta: true
         returns: A [run](/docs/api-reference/runs/object) object.
         examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/threads/runs \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1" \
-                -d '{
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                      "assistant_id": "asst_abc123",
+                      "thread": {
+                        "messages": [
+                          {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                        ]
+                      }
+                    }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                run = client.beta.threads.create_and_run(
+                  assistant_id="asst_abc123",
+                  thread={
+                    "messages": [
+                      {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                    ]
+                  }
+                )
+
+                print(run)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const run = await openai.beta.threads.createAndRun({
+                    assistant_id: "asst_abc123",
+                    thread: {
+                      messages: [
+                        { role: "user", content: "Explain deep learning to a 5 year old." },
+                      ],
+                    },
+                  });
+
+                  console.log(run);
+                }
+
+                main();
+            response: |
+              {
+                "id": "run_abc123",
+                "object": "thread.run",
+                "created_at": 1699076792,
+                "assistant_id": "asst_abc123",
+                "thread_id": "thread_abc123",
+                "status": "queued",
+                "started_at": null,
+                "expires_at": 1699077392,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": null,
+                "required_action": null,
+                "last_error": null,
+                "model": "gpt-4-turbo",
+                "instructions": "You are a helpful assistant.",
+                "tools": [],
+                "tool_resources": {},
+                "metadata": {},
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_completion_tokens": null,
+                "max_prompt_tokens": null,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "incomplete_details": null,
+                "usage": null,
+                "response_format": "auto",
+                "tool_choice": "auto"
+              }
+
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_123",
+                    "thread": {
+                      "messages": [
+                        {"role": "user", "content": "Hello"}
+                      ]
+                    },
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.create_and_run(
+                  assistant_id="asst_123",
+                  thread={
+                    "messages": [
+                      {"role": "user", "content": "Hello"}
+                    ]
+                  },
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.beta.threads.createAndRun({
+                      assistant_id: "asst_123",
+                      thread: {
+                        messages: [
+                          { role: "user", content: "Hello" },
+                        ],
+                      },
+                      stream: true
+                  });
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: |
+              event: thread.created
+              data: {"id":"thread_123","object":"thread","created_at":1710348075,"metadata":{}}
+
+              event: thread.run.created
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}
+
+              event: thread.run.queued
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}
+
+              event: thread.run.in_progress
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}
+
+              event: thread.run.step.created
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.run.step.in_progress
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.message.created
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+              event: thread.message.in_progress
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[], "metadata":{}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+              ...
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+              event: thread.message.completed
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}], "metadata":{}}
+
+              event: thread.run.step.completed
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+              event: thread.run.completed
+              {"id":"run_123","object":"thread.run","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1713226836,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1713226837,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto"}
+
+              event: done
+              data: [DONE]
+
+          - title: Streaming with Functions
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
                     "assistant_id": "asst_abc123",
                     "thread": {
                       "messages": [
-                        {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                        {"role": "user", "content": "What is the weather like in San Francisco?"}
                       ]
-                    }
-                  }'
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
-
-              run = client.beta.threads.create_and_run(
-                assistant_id="asst_abc123",
-                thread={
-                  "messages": [
-                    {"role": "user", "content": "Explain deep learning to a 5 year old."}
-                  ]
-                }
-              )
-            node.js: |
-              import OpenAI from "openai";
-
-              const openai = new OpenAI();
-
-              async function main() {
-                const run = await openai.beta.threads.createAndRun({
-                  assistant_id: "asst_abc123",
-                  thread: {
-                    messages: [
-                      { role: "user", content: "Explain deep learning to a 5 year old." },
+                    },
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"]
+                              }
+                            },
+                            "required": ["location"]
+                          }
+                        }
+                      }
                     ],
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                tools = [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                          },
+                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                      },
+                    }
+                  }
+                ]
+
+                stream = client.beta.threads.create_and_run(
+                  thread={
+                      "messages": [
+                        {"role": "user", "content": "What is the weather like in San Francisco?"}
+                      ]
                   },
-                });
+                  assistant_id="asst_abc123",
+                  tools=tools,
+                  stream=True
+                )
 
-                console.log(run);
-              }
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
 
-              main();
-          response: |
-            {
-              "id": "run_abc123",
-              "object": "thread.run",
-              "created_at": 1699076792,
-              "assistant_id": "asst_abc123",
-              "thread_id": "thread_abc123",
-              "status": "queued",
-              "started_at": null,
-              "expires_at": 1699077392,
-              "cancelled_at": null,
-              "failed_at": null,
-              "completed_at": null,
-              "last_error": null,
-              "model": "gpt-4",
-              "instructions": "You are a helpful assistant.",
-              "tools": [],
-              "file_ids": [],
-              "metadata": {},
-              "usage": null
-            }
+                const openai = new OpenAI();
+
+                const tools = [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                          },
+                          "required": ["location"],
+                        },
+                      }
+                    }
+                ];
+
+                async function main() {
+                  const stream = await openai.beta.threads.createAndRun({
+                    assistant_id: "asst_123",
+                    thread: {
+                      messages: [
+                        { role: "user", content: "What is the weather like in San Francisco?" },
+                      ],
+                    },
+                    tools: tools,
+                    stream: true
+                  });
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: |
+              event: thread.created
+              data: {"id":"thread_123","object":"thread","created_at":1710351818,"metadata":{}}
+
+              event: thread.run.created
+              data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.queued
+              data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.in_progress
+              data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.step.created
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+              event: thread.run.step.in_progress
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+              event: thread.run.step.delta
+              data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"","output":null}}]}}}
+
+              event: thread.run.step.delta
+              data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\""}}]}}}
+
+              event: thread.run.step.delta
+              data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"location"}}]}}}
+
+              ...
+
+              event: thread.run.step.delta
+              data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"ahrenheit"}}]}}}
+
+              event: thread.run.step.delta
+              data: {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"}"}}]}}}
+
+              event: thread.run.requires_action
+              data: {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"requires_action","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":{"type":"submit_tool_outputs","submit_tool_outputs":{"tool_calls":[{"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}"}}]}},"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto"}}
+
+              event: done
+              data: [DONE]
 
   /threads/{thread_id}/runs:
     get:
@@ -3697,7 +4327,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/runs \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -3705,6 +4335,7 @@ paths:
               runs = client.beta.threads.runs.list(
                 "thread_abc123"
               )
+
               print(runs)
             node.js: |
               import OpenAI from "openai";
@@ -3737,23 +4368,38 @@ paths:
                   "failed_at": null,
                   "completed_at": 1699075073,
                   "last_error": null,
-                  "model": "gpt-3.5-turbo",
+                  "model": "gpt-4-turbo",
                   "instructions": null,
+                  "incomplete_details": null,
                   "tools": [
                     {
                       "type": "code_interpreter"
                     }
                   ],
-                  "file_ids": [
-                    "file-abc123",
-                    "file-abc456"
-                  ],
+                  "tool_resources": {
+                    "code_interpreter": {
+                      "file_ids": [
+                        "file-abc123",
+                        "file-abc456"
+                      ]
+                    }
+                  },
                   "metadata": {},
                   "usage": {
                     "prompt_tokens": 123,
                     "completion_tokens": 456,
                     "total_tokens": 579
-                  }
+                  },
+                  "temperature": 1.0,
+                  "top_p": 1.0,
+                  "max_prompt_tokens": 1000,
+                  "max_completion_tokens": 1000,
+                  "truncation_strategy": {
+                    "type": "auto",
+                    "last_messages": null
+                  },
+                  "response_format": "auto",
+                  "tool_choice": "auto"
                 },
                 {
                   "id": "run_abc456",
@@ -3768,23 +4414,38 @@ paths:
                   "failed_at": null,
                   "completed_at": 1699063291,
                   "last_error": null,
-                  "model": "gpt-3.5-turbo",
+                  "model": "gpt-4-turbo",
                   "instructions": null,
+                  "incomplete_details": null,
                   "tools": [
                     {
                       "type": "code_interpreter"
                     }
                   ],
-                  "file_ids": [
-                    "file-abc123",
-                    "file-abc456"
-                  ],
+                  "tool_resources": {
+                    "code_interpreter": {
+                      "file_ids": [
+                        "file-abc123",
+                        "file-abc456"
+                      ]
+                    }
+                  },
                   "metadata": {},
                   "usage": {
                     "prompt_tokens": 123,
                     "completion_tokens": 456,
                     "total_tokens": 579
-                  }
+                  },
+                  "temperature": 1.0,
+                  "top_p": 1.0,
+                  "max_prompt_tokens": 1000,
+                  "max_completion_tokens": 1000,
+                  "truncation_strategy": {
+                    "type": "auto",
+                    "last_messages": null
+                  },
+                  "response_format": "auto",
+                  "tool_choice": "auto"
                 }
               ],
               "first_id": "run_abc123",
@@ -3822,67 +4483,315 @@ paths:
         beta: true
         returns: A [run](/docs/api-reference/runs/object) object.
         examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/threads/thread_abc123/runs \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1" \
-                -d '{
-                  "assistant_id": "asst_abc123"
-                }'
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_abc123"
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
 
-              run = client.beta.threads.runs.create(
-                thread_id="thread_abc123",
-                assistant_id="asst_abc123"
-              )
-              print(run)
-            node.js: |
-              import OpenAI from "openai";
+                run = client.beta.threads.runs.create(
+                  thread_id="thread_abc123",
+                  assistant_id="asst_abc123"
+                )
 
-              const openai = new OpenAI();
+                print(run)
+              node.js: |
+                import OpenAI from "openai";
 
-              async function main() {
-                const run = await openai.beta.threads.runs.create(
-                  "thread_abc123",
-                  { assistant_id: "asst_abc123" }
-                );
+                const openai = new OpenAI();
 
-                console.log(run);
-              }
+                async function main() {
+                  const run = await openai.beta.threads.runs.create(
+                    "thread_abc123",
+                    { assistant_id: "asst_abc123" }
+                  );
 
-              main();
-          response: &run_object_example |
-            {
-              "id": "run_abc123",
-              "object": "thread.run",
-              "created_at": 1699063290,
-              "assistant_id": "asst_abc123",
-              "thread_id": "thread_abc123",
-              "status": "queued",
-              "started_at": 1699063290,
-              "expires_at": null,
-              "cancelled_at": null,
-              "failed_at": null,
-              "completed_at": 1699063291,
-              "last_error": null,
-              "model": "gpt-4",
-              "instructions": null,
-              "tools": [
-                {
-                  "type": "code_interpreter"
+                  console.log(run);
                 }
-              ],
-              "file_ids": [
-                "file-abc123",
-                "file-abc456"
-              ],
-              "metadata": {},
-              "usage": null
-            }
+
+                main();
+            response: &run_object_example |
+              {
+                "id": "run_abc123",
+                "object": "thread.run",
+                "created_at": 1699063290,
+                "assistant_id": "asst_abc123",
+                "thread_id": "thread_abc123",
+                "status": "queued",
+                "started_at": 1699063290,
+                "expires_at": null,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": 1699063291,
+                "last_error": null,
+                "model": "gpt-4-turbo",
+                "instructions": null,
+                "incomplete_details": null,
+                "tools": [
+                  {
+                    "type": "code_interpreter"
+                  }
+                ],
+                "metadata": {},
+                "usage": null,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_prompt_tokens": 1000,
+                "max_completion_tokens": 1000,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "response_format": "auto",
+                "tool_choice": "auto"
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_123",
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.runs.create(
+                  thread_id="thread_123",
+                  assistant_id="asst_123",
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.create(
+                    "thread_123",
+                    { assistant_id: "asst_123", stream: true }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: |
+              event: thread.run.created
+              data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.queued
+              data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.in_progress
+              data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710330641,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.step.created
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.run.step.in_progress
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.message.created
+              data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.in_progress
+              data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+              ...
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+              event: thread.message.completed
+              data: {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710330642,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+              event: thread.run.step.completed
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710330642,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+              event: thread.run.completed
+              data: {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710330641,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710330642,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto"}}
+
+              event: done
+              data: [DONE]
+
+          - title: Streaming with Functions
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_abc123",
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"]
+                              }
+                            },
+                            "required": ["location"]
+                          }
+                        }
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                tools = [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                          },
+                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                      },
+                    }
+                  }
+                ]
+
+                stream = client.beta.threads.runs.create(
+                  thread_id="thread_abc123",
+                  assistant_id="asst_abc123",
+                  tools=tools,
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                const tools = [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                          },
+                          "required": ["location"],
+                        },
+                      }
+                    }
+                ];
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.create(
+                    "thread_abc123",
+                    {
+                      assistant_id: "asst_abc123",
+                      tools: tools,
+                      stream: true
+                    }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: |
+              event: thread.run.created
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.queued
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.in_progress
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710348075,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.step.created
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.run.step.in_progress
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+              event: thread.message.created
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.in_progress
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+              ...
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" today"}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+              event: thread.message.completed
+              data: {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello! How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+              event: thread.run.step.completed
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+              event: thread.run.completed
+              data: {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710348075,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710348077,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto"}}
+
+              event: done
+              data: [DONE]
 
   /threads/{thread_id}/runs/{run_id}:
     get:
@@ -3920,7 +4829,7 @@ paths:
             curl: |
               curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -3929,6 +4838,7 @@ paths:
                 thread_id="thread_abc123",
                 run_id="run_abc123"
               )
+
               print(run)
             node.js: |
               import OpenAI from "openai";
@@ -3959,23 +4869,30 @@ paths:
               "failed_at": null,
               "completed_at": 1699075073,
               "last_error": null,
-              "model": "gpt-3.5-turbo",
+              "model": "gpt-4-turbo",
               "instructions": null,
+              "incomplete_details": null,
               "tools": [
                 {
                   "type": "code_interpreter"
                 }
-              ],
-              "file_ids": [
-                "file-abc123",
-                "file-abc456"
               ],
               "metadata": {},
               "usage": {
                 "prompt_tokens": 123,
                 "completion_tokens": 456,
                 "total_tokens": 579
-              }
+              },
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "max_prompt_tokens": 1000,
+              "max_completion_tokens": 1000,
+              "truncation_strategy": {
+                "type": "auto",
+                "last_messages": null
+              },
+              "response_format": "auto",
+              "tool_choice": "auto"
             }
     post:
       operationId: modifyRun
@@ -4019,7 +4936,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -d '{
                   "metadata": {
                     "user_id": "user_abc123"
@@ -4034,6 +4951,7 @@ paths:
                 run_id="run_abc123",
                 metadata={"user_id": "user_abc123"},
               )
+
               print(run)
             node.js: |
               import OpenAI from "openai";
@@ -4069,17 +4987,22 @@ paths:
               "failed_at": null,
               "completed_at": 1699075073,
               "last_error": null,
-              "model": "gpt-3.5-turbo",
+              "model": "gpt-4-turbo",
               "instructions": null,
+              "incomplete_details": null,
               "tools": [
                 {
                   "type": "code_interpreter"
                 }
               ],
-              "file_ids": [
-                "file-abc123",
-                "file-abc456"
-              ],
+              "tool_resources": {
+                "code_interpreter": {
+                  "file_ids": [
+                    "file-abc123",
+                    "file-abc456"
+                  ]
+                }
+              },
               "metadata": {
                 "user_id": "user_abc123"
               },
@@ -4087,7 +5010,17 @@ paths:
                 "prompt_tokens": 123,
                 "completion_tokens": 456,
                 "total_tokens": 579
-              }
+              },
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "max_prompt_tokens": 1000,
+              "max_completion_tokens": 1000,
+              "truncation_strategy": {
+                "type": "auto",
+                "last_messages": null
+              },
+              "response_format": "auto",
+              "tool_choice": "auto"
             }
 
   /threads/{thread_id}/runs/{run_id}/submit_tool_outputs:
@@ -4129,106 +5062,222 @@ paths:
         beta: true
         returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
         examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1" \
-                -d '{
-                  "tool_outputs": [
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "tool_outputs": [
+                      {
+                        "tool_call_id": "call_001",
+                        "output": "70 degrees and sunny."
+                      }
+                    ]
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                run = client.beta.threads.runs.submit_tool_outputs(
+                  thread_id="thread_123",
+                  run_id="run_123",
+                  tool_outputs=[
                     {
-                      "tool_call_id": "call_abc123",
-                      "output": "28C"
+                      "tool_call_id": "call_001",
+                      "output": "70 degrees and sunny."
                     }
                   ]
-                }'
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
+                )
 
-              run = client.beta.threads.runs.submit_tool_outputs(
-                thread_id="thread_abc123",
-                run_id="run_abc123",
-                tool_outputs=[
-                  {
-                    "tool_call_id": "call_abc123",
-                    "output": "28C"
-                  }
-                ]
-              )
-              print(run)
-            node.js: |
-              import OpenAI from "openai";
+                print(run)
+              node.js: |
+                import OpenAI from "openai";
 
-              const openai = new OpenAI();
+                const openai = new OpenAI();
 
-              async function main() {
-                const run = await openai.beta.threads.runs.submitToolOutputs(
-                  "thread_abc123",
-                  "run_abc123",
-                  {
-                    tool_outputs: [
-                      {
-                        tool_call_id: "call_abc123",
-                        output: "28C",
-                      },
-                    ],
-                  }
-                );
-
-                console.log(run);
-              }
-
-              main();
-          response: |
-            {
-              "id": "run_abc123",
-              "object": "thread.run",
-              "created_at": 1699075592,
-              "assistant_id": "asst_abc123",
-              "thread_id": "thread_abc123",
-              "status": "queued",
-              "started_at": 1699075592,
-              "expires_at": 1699076192,
-              "cancelled_at": null,
-              "failed_at": null,
-              "completed_at": null,
-              "last_error": null,
-              "model": "gpt-4",
-              "instructions": "You tell the weather.",
-              "tools": [
-                {
-                  "type": "function",
-                  "function": {
-                    "name": "get_weather",
-                    "description": "Determine weather in my location",
-                    "parameters": {
-                      "type": "object",
-                      "properties": {
-                        "location": {
-                          "type": "string",
-                          "description": "The city and state e.g. San Francisco, CA"
+                async function main() {
+                  const run = await openai.beta.threads.runs.submitToolOutputs(
+                    "thread_123",
+                    "run_123",
+                    {
+                      tool_outputs: [
+                        {
+                          tool_call_id: "call_001",
+                          output: "70 degrees and sunny.",
                         },
-                        "unit": {
-                          "type": "string",
-                          "enum": [
-                            "c",
-                            "f"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "location"
-                      ]
+                      ],
+                    }
+                  );
+
+                  console.log(run);
+                }
+
+                main();
+            response: |
+              {
+                "id": "run_123",
+                "object": "thread.run",
+                "created_at": 1699075592,
+                "assistant_id": "asst_123",
+                "thread_id": "thread_123",
+                "status": "queued",
+                "started_at": 1699075592,
+                "expires_at": 1699076192,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": null,
+                "last_error": null,
+                "model": "gpt-4-turbo",
+                "instructions": null,
+                "tools": [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"]
+                          }
+                        },
+                        "required": ["location"]
+                      }
                     }
                   }
+                ],
+                "metadata": {},
+                "usage": null,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_prompt_tokens": 1000,
+                "max_completion_tokens": 1000,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "response_format": "auto",
+                "tool_choice": "auto"
+              }
+
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "tool_outputs": [
+                      {
+                        "tool_call_id": "call_001",
+                        "output": "70 degrees and sunny."
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.runs.submit_tool_outputs(
+                  thread_id="thread_123",
+                  run_id="run_123",
+                  tool_outputs=[
+                    {
+                      "tool_call_id": "call_001",
+                      "output": "70 degrees and sunny."
+                    }
+                  ],
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.submitToolOutputs(
+                    "thread_123",
+                    "run_123",
+                    {
+                      tool_outputs: [
+                        {
+                          tool_call_id: "call_001",
+                          output: "70 degrees and sunny.",
+                        },
+                      ],
+                    }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
                 }
-              ],
-              "file_ids": [],
-              "metadata": {},
-              "usage": null
-            }
+
+                main();
+            response: |
+              event: thread.run.step.completed
+              data: {"id":"step_001","object":"thread.run.step","created_at":1710352449,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"completed","cancelled_at":null,"completed_at":1710352475,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[{"id":"call_iWr0kQ2EaYMaxNdl0v3KYkx7","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San Francisco, CA\",\"unit\":\"fahrenheit\"}","output":"70 degrees and sunny."}}]},"usage":{"prompt_tokens":291,"completion_tokens":24,"total_tokens":315}}
+
+              event: thread.run.queued
+              data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":1710352448,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.in_progress
+              data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710352475,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto"}}
+
+              event: thread.run.step.created
+              data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+              event: thread.run.step.in_progress
+              data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+              event: thread.message.created
+              data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.in_progress
+              data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+              event: thread.message.delta
+              data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"The","annotations":[]}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" current"}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" weather"}}]}}
+
+              ...
+
+              event: thread.message.delta
+              data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":" sunny"}}]}}
+
+              event: thread.message.delta
+              data: {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"."}}]}}
+
+              event: thread.message.completed
+              data: {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710352477,"role":"assistant","content":[{"type":"text","text":{"value":"The current weather in San Francisco, CA is 70 degrees Fahrenheit and sunny.","annotations":[]}}],"metadata":{}}
+
+              event: thread.run.step.completed
+              data: {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710352477,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":{"prompt_tokens":329,"completion_tokens":18,"total_tokens":347}}
+
+              event: thread.run.completed
+              data: {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710352475,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710352477,"required_action":null,"last_error":null,"model":"gpt-4-turbo","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto"}}
+
+              event: done
+              data: [DONE]
 
   /threads/{thread_id}/runs/{run_id}/cancel:
     post:
@@ -4266,7 +5315,7 @@ paths:
             curl: |
               curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/cancel \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "OpenAI-Beta: assistants=v1" \
+                -H "OpenAI-Beta: assistants=v2" \
                 -X POST
             python: |
               from openai import OpenAI
@@ -4276,6 +5325,7 @@ paths:
                 thread_id="thread_abc123",
                 run_id="run_abc123"
               )
+
               print(run)
             node.js: |
               import OpenAI from "openai";
@@ -4306,16 +5356,23 @@ paths:
               "failed_at": null,
               "completed_at": null,
               "last_error": null,
-              "model": "gpt-4",
+              "model": "gpt-4-turbo",
               "instructions": "You summarize books.",
               "tools": [
                 {
-                  "type": "retrieval"
+                  "type": "file_search"
                 }
               ],
-              "file_ids": [],
+              "tool_resources": {
+                "file_search": {
+                  "vector_store_ids": ["vs_123"]
+                }
+              },
               "metadata": {},
-              "usage": null
+              "usage": null,
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "response_format": "auto"
             }
 
   /threads/{thread_id}/runs/{run_id}/steps:
@@ -4379,7 +5436,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -4388,6 +5445,7 @@ paths:
                   thread_id="thread_abc123",
                   run_id="run_abc123"
               )
+
               print(run_steps)
             node.js: |
               import OpenAI from "openai";
@@ -4481,7 +5539,7 @@ paths:
               curl https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123 \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
@@ -4491,6 +5549,7 @@ paths:
                   run_id="run_abc123",
                   step_id="step_abc123"
               )
+
               print(run_step)
             node.js: |
               import OpenAI from "openai";
@@ -4534,19 +5593,13 @@ paths:
               }
             }
 
-  /assistants/{assistant_id}/files:
+  /vector_stores:
     get:
-      operationId: listAssistantFiles
+      operationId: listVectorStores
       tags:
-        - Assistants
-      summary: Returns a list of assistant files.
+        - Vector Stores
+      summary: Returns a list of vector stores.
       parameters:
-        - name: assistant_id
-          in: path
-          description: The ID of the assistant the file belongs to.
-          required: true
-          schema:
-            type: string
         - name: limit
           in: query
           description: *pagination_limit_param_description
@@ -4577,36 +5630,417 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListAssistantFilesResponse"
+                $ref: "#/components/schemas/ListVectorStoresResponse"
       x-oaiMeta:
-        name: List assistant files
-        group: assistants
+        name: List vector stores
+        group: vector_stores
         beta: true
-        returns: A list of [assistant file](/docs/api-reference/assistants/file-object) objects.
+        returns: A list of [vector store](/docs/api-reference/vector-stores/object) objects.
         examples:
           request:
             curl: |
-              curl https://api.openai.com/v1/assistants/asst_abc123/files \
+              curl https://api.openai.com/v1/vector_stores \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
 
-              assistant_files = client.beta.assistants.files.list(
-                assistant_id="asst_abc123"
-              )
-              print(assistant_files)
+              vector_stores = client.beta.vector_stores.list()
+              print(vector_stores)
             node.js: |
               import OpenAI from "openai";
               const openai = new OpenAI();
 
               async function main() {
-                const assistantFiles = await openai.beta.assistants.files.list(
-                  "asst_abc123"
+                const vectorStores = await openai.beta.vectorStores.list();
+                console.log(vectorStores);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "vs_abc123",
+                  "object": "vector_store",
+                  "created_at": 1699061776,
+                  "name": "Support FAQ",
+                  "bytes": 139920,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
+                },
+                {
+                  "id": "vs_abc456",
+                  "object": "vector_store",
+                  "created_at": 1699061776,
+                  "name": "Support FAQ v2",
+                  "bytes": 139920,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
+                }
+              ],
+              "first_id": "vs_abc123",
+              "last_id": "vs_abc456",
+              "has_more": false
+            }
+    post:
+      operationId: createVectorStore
+      tags:
+        - Vector Stores
+      summary: Create a vector store.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVectorStoreRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Create vector store
+        group: vector_stores
+        beta: true
+        returns: A [vector store](/docs/api-reference/vector-stores/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+                -d '{
+                  "name": "Support FAQ"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.create(
+                name="Support FAQ"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.create({
+                  name: "Support FAQ"
+                });
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776,
+              "name": "Support FAQ",
+              "bytes": 139920,
+              "file_counts": {
+                "in_progress": 0,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 3
+              }
+            }
+
+  /vector_stores/{vector_store_id}:
+    get:
+      operationId: getVectorStore
+      tags:
+        - Vector Stores
+      summary: Retrieves a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Retrieve vector store
+        group: vector_stores
+        beta: true
+        returns: The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.retrieve(
+                vector_store_id="vs_abc123"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.retrieve(
+                  "vs_abc123"
                 );
-                console.log(assistantFiles);
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776
+            }
+    post:
+      operationId: modifyVectorStore
+      tags:
+        - Vector Stores
+      summary: Modifies a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to modify.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateVectorStoreRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Modify vector store
+        group: vector_stores
+        beta: true
+        returns: The modified [vector store](/docs/api-reference/vector-stores/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+                -d '{
+                  "name": "Support FAQ"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.update(
+                vector_store_id="vs_abc123",
+                name="Support FAQ"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.update(
+                  "vs_abc123",
+                  {
+                    name: "Support FAQ"
+                  }
+                );
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776,
+              "name": "Support FAQ",
+              "bytes": 139920,
+              "file_counts": {
+                "in_progress": 0,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 3
+              }
+            }
+
+    delete:
+      operationId: deleteVectorStore
+      tags:
+        - Vector Stores
+      summary: Delete a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteVectorStoreResponse"
+      x-oaiMeta:
+        name: Delete vector store
+        group: vector_stores
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_vector_store = client.beta.vector_stores.delete(
+                vector_store_id="vs_abc123"
+              )
+              print(deleted_vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedVectorStore = await openai.beta.vectorStores.del(
+                  "vs_abc123"
+                );
+                console.log(deletedVectorStore);
+              }
+
+              main();
+          response: |
+            {
+              id: "vs_abc123",
+              object: "vector_store.deleted",
+              deleted: true
+            }
+
+  /vector_stores/{vector_store_id}/files:
+    get:
+      operationId: listVectorStoreFiles
+      tags:
+        - Vector Stores
+      summary: Returns a list of vector store files.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: The ID of the vector store that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: *pagination_limit_param_description
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: *pagination_order_param_description
+          schema:
+            type: string
+            default: desc
+            enum: ["asc", "desc"]
+        - name: after
+          in: query
+          description: *pagination_after_param_description
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: *pagination_before_param_description
+          schema:
+            type: string
+        - name: filter
+          in: query
+          description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+          schema:
+            type: string
+            enum: ["in_progress", "completed", "failed", "cancelled"]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+      x-oaiMeta:
+        name: List vector store files
+        group: vector_stores
+        beta: true
+        returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_files = client.beta.vector_stores.files.list(
+                vector_store_id="vs_abc123"
+              )
+              print(vector_store_files)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStoreFiles = await openai.beta.vectorStores.files.list(
+                  "vs_abc123"
+                );
+                console.log(vectorStoreFiles);
               }
 
               main();
@@ -4616,15 +6050,15 @@ paths:
               "data": [
                 {
                   "id": "file-abc123",
-                  "object": "assistant.file",
-                  "created_at": 1699060412,
-                  "assistant_id": "asst_abc123"
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
                 },
                 {
                   "id": "file-abc456",
-                  "object": "assistant.file",
-                  "created_at": 1699060412,
-                  "assistant_id": "asst_abc123"
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
                 }
               ],
               "first_id": "file-abc123",
@@ -4632,44 +6066,44 @@ paths:
               "has_more": false
             }
     post:
-      operationId: createAssistantFile
+      operationId: createVectorStoreFile
       tags:
-        - Assistants
-      summary: Create an assistant file by attaching a [File](/docs/api-reference/files) to an [assistant](/docs/api-reference/assistants).
+        - Vector Stores
+      summary: Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).
       parameters:
         - in: path
-          name: assistant_id
+          name: vector_store_id
           required: true
           schema:
             type: string
-            example: file-abc123
+            example: vs_abc123
           description: |
-            The ID of the assistant for which to create a File.
+            The ID of the vector store for which to create a File.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateAssistantFileRequest"
+              $ref: "#/components/schemas/CreateVectorStoreFileRequest"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssistantFileObject"
+                $ref: "#/components/schemas/VectorStoreFileObject"
       x-oaiMeta:
-        name: Create assistant file
-        group: assistants
+        name: Create vector store file
+        group: vector_stores
         beta: true
-        returns: An [assistant file](/docs/api-reference/assistants/file-object) object.
+        returns: A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
         examples:
           request:
             curl: |
-              curl https://api.openai.com/v1/assistants/asst_abc123/files \
-                  -H 'Authorization: Bearer $OPENAI_API_KEY"' \
-                  -H 'Content-Type: application/json' \
-                  -H 'OpenAI-Beta: assistants=v1' \
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
                   -d '{
                     "file_id": "file-abc123"
                   }'
@@ -4677,289 +6111,51 @@ paths:
               from openai import OpenAI
               client = OpenAI()
 
-              assistant_file = client.beta.assistants.files.create(
-                assistant_id="asst_abc123",
+              vector_store_file = client.beta.vector_stores.files.create(
+                vector_store_id="vs_abc123",
                 file_id="file-abc123"
               )
-              print(assistant_file)
+              print(vector_store_file)
             node.js: |
               import OpenAI from "openai";
               const openai = new OpenAI();
 
               async function main() {
-                const myAssistantFile = await openai.beta.assistants.files.create(
-                  "asst_abc123",
+                const myVectorStoreFile = await openai.beta.vectorStores.files.create(
+                  "vs_abc123",
                   {
                     file_id: "file-abc123"
                   }
                 );
-                console.log(myAssistantFile);
+                console.log(myVectorStoreFile);
               }
 
               main();
-          response: &assistant_file_object |
+          response: |
             {
               "id": "file-abc123",
-              "object": "assistant.file",
-              "created_at": 1699055364,
-              "assistant_id": "asst_abc123"
+              "object": "vector_store.file",
+              "created_at": 1699061776,
+              "usage_bytes": 1234,
+              "vector_store_id": "vs_abcd",
+              "status": "completed",
+              "last_error": null
             }
 
-  /assistants/{assistant_id}/files/{file_id}:
+  /vector_stores/{vector_store_id}/files/{file_id}:
     get:
-      operationId: getAssistantFile
+      operationId: getVectorStoreFile
       tags:
-        - Assistants
-      summary: Retrieves an AssistantFile.
+        - Vector Stores
+      summary: Retrieves a vector store file.
       parameters:
         - in: path
-          name: assistant_id
+          name: vector_store_id
           required: true
           schema:
             type: string
-          description: The ID of the assistant who the file belongs to.
-        - in: path
-          name: file_id
-          required: true
-          schema:
-            type: string
-          description: The ID of the file we're getting.
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AssistantFileObject"
-      x-oaiMeta:
-        name: Retrieve assistant file
-        group: assistants
-        beta: true
-        returns: The [assistant file](/docs/api-reference/assistants/file-object) object matching the specified ID.
-        examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/assistants/asst_abc123/files/file-abc123 \
-                -H 'Authorization: Bearer $OPENAI_API_KEY"' \
-                -H 'Content-Type: application/json' \
-                -H 'OpenAI-Beta: assistants=v1'
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
-
-              assistant_file = client.beta.assistants.files.retrieve(
-                assistant_id="asst_abc123",
-                file_id="file-abc123"
-              )
-              print(assistant_file)
-            node.js: |
-              import OpenAI from "openai";
-              const openai = new OpenAI();
-
-              async function main() {
-                const myAssistantFile = await openai.beta.assistants.files.retrieve(
-                  "asst_abc123",
-                  "file-abc123"
-                );
-                console.log(myAssistantFile);
-              }
-
-              main();
-          response: *assistant_file_object
-    delete:
-      operationId: deleteAssistantFile
-      tags:
-        - Assistants
-      summary: Delete an assistant file.
-      parameters:
-        - in: path
-          name: assistant_id
-          required: true
-          schema:
-            type: string
-          description: The ID of the assistant that the file belongs to.
-        - in: path
-          name: file_id
-          required: true
-          schema:
-            type: string
-          description: The ID of the file to delete.
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DeleteAssistantFileResponse"
-      x-oaiMeta:
-        name: Delete assistant file
-        group: assistants
-        beta: true
-        returns: Deletion status
-        examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/assistants/asst_abc123/files/file-abc123 \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1" \
-                -X DELETE
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
-
-              deleted_assistant_file = client.beta.assistants.files.delete(
-                  assistant_id="asst_abc123",
-                  file_id="file-abc123"
-              )
-              print(deleted_assistant_file)
-            node.js: |
-              import OpenAI from "openai";
-              const openai = new OpenAI();
-
-              async function main() {
-                const deletedAssistantFile = await openai.beta.assistants.files.del(
-                  "asst_abc123",
-                  "file-abc123"
-                );
-                console.log(deletedAssistantFile);
-              }
-
-              main();
-          response: |
-            {
-              id: "file-abc123",
-              object: "assistant.file.deleted",
-              deleted: true
-            }
-
-  /threads/{thread_id}/messages/{message_id}/files:
-    get:
-      operationId: listMessageFiles
-      tags:
-        - Assistants
-      summary: Returns a list of message files.
-      parameters:
-        - name: thread_id
-          in: path
-          description: The ID of the thread that the message and files belong to.
-          required: true
-          schema:
-            type: string
-        - name: message_id
-          in: path
-          description: The ID of the message that the files belongs to.
-          required: true
-          schema:
-            type: string
-        - name: limit
-          in: query
-          description: *pagination_limit_param_description
-          required: false
-          schema:
-            type: integer
-            default: 20
-        - name: order
-          in: query
-          description: *pagination_order_param_description
-          schema:
-            type: string
-            default: desc
-            enum: ["asc", "desc"]
-        - name: after
-          in: query
-          description: *pagination_after_param_description
-          schema:
-            type: string
-        - name: before
-          in: query
-          description: *pagination_before_param_description
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ListMessageFilesResponse"
-      x-oaiMeta:
-        name: List message files
-        group: threads
-        beta: true
-        returns: A list of [message file](/docs/api-reference/messages/file-object) objects.
-        examples:
-          request:
-            curl: |
-              curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123/files \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
-            python: |
-              from openai import OpenAI
-              client = OpenAI()
-
-              message_files = client.beta.threads.messages.files.list(
-                thread_id="thread_abc123",
-                message_id="msg_abc123"
-              )
-              print(message_files)
-            node.js: |
-              import OpenAI from "openai";
-              const openai = new OpenAI();
-
-              async function main() {
-                const messageFiles = await openai.beta.threads.messages.files.list(
-                  "thread_abc123",
-                  "msg_abc123"
-                );
-                console.log(messageFiles);
-              }
-
-              main();
-          response: |
-            {
-              "object": "list",
-              "data": [
-                {
-                  "id": "file-abc123",
-                  "object": "thread.message.file",
-                  "created_at": 1699061776,
-                  "message_id": "msg_abc123"
-                },
-                {
-                  "id": "file-abc123",
-                  "object": "thread.message.file",
-                  "created_at": 1699061776,
-                  "message_id": "msg_abc123"
-                }
-              ],
-              "first_id": "file-abc123",
-              "last_id": "file-abc123",
-              "has_more": false
-            }
-
-  /threads/{thread_id}/messages/{message_id}/files/{file_id}:
-    get:
-      operationId: getMessageFile
-      tags:
-        - Assistants
-      summary: Retrieves a message file.
-      parameters:
-        - in: path
-          name: thread_id
-          required: true
-          schema:
-            type: string
-            example: thread_abc123
-          description: The ID of the thread to which the message and File belong.
-        - in: path
-          name: message_id
-          required: true
-          schema:
-            type: string
-            example: msg_abc123
-          description: The ID of the message the file belongs to.
+            example: vs_abc123
+          description: The ID of the vector store that the file belongs to.
         - in: path
           name: file_id
           required: true
@@ -4973,49 +6169,833 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MessageFileObject"
+                $ref: "#/components/schemas/VectorStoreFileObject"
       x-oaiMeta:
-        name: Retrieve message file
-        group: threads
+        name: Retrieve vector store file
+        group: vector_stores
         beta: true
-        returns: The [message file](/docs/api-reference/messages/file-object) object.
+        returns: The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
         examples:
           request:
             curl: |
-              curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123/files/file-abc123 \
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
                 -H "Authorization: Bearer $OPENAI_API_KEY" \
                 -H "Content-Type: application/json" \
-                -H "OpenAI-Beta: assistants=v1"
+                -H "OpenAI-Beta: assistants=v2"
             python: |
               from openai import OpenAI
               client = OpenAI()
 
-              message_files = client.beta.threads.messages.files.retrieve(
-                  thread_id="thread_abc123",
-                  message_id="msg_abc123",
-                  file_id="file-abc123"
+              vector_store_file = client.beta.vector_stores.files.retrieve(
+                vector_store_id="vs_abc123",
+                file_id="file-abc123"
               )
-              print(message_files)
+              print(vector_store_file)
             node.js: |
               import OpenAI from "openai";
               const openai = new OpenAI();
 
               async function main() {
-                const messageFile = await openai.beta.threads.messages.files.retrieve(
-                  "thread_abc123",
-                  "msg_abc123",
+                const vectorStoreFile = await openai.beta.vectorStores.files.retrieve(
+                  "vs_abc123",
                   "file-abc123"
                 );
-                console.log(messageFile);
+                console.log(vectorStoreFile);
               }
 
               main();
           response: |
             {
               "id": "file-abc123",
-              "object": "thread.message.file",
+              "object": "vector_store.file",
               "created_at": 1699061776,
-              "message_id": "msg_abc123"
+              "vector_store_id": "vs_abcd",
+              "status": "completed",
+              "last_error": null
+            }
+    delete:
+      operationId: deleteVectorStoreFile
+      tags:
+        - Vector Stores
+      summary: Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store that the file belongs to.
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+      x-oaiMeta:
+        name: Delete vector store file
+        group: vector_stores
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_vector_store_file = client.beta.vector_stores.files.delete(
+                  vector_store_id="vs_abc123",
+                  file_id="file-abc123"
+              )
+              print(deleted_vector_store_file)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedVectorStoreFile = await openai.beta.vectorStores.files.del(
+                  "vs_abc123",
+                  "file-abc123"
+                );
+                console.log(deletedVectorStoreFile);
+              }
+
+              main();
+          response: |
+            {
+              id: "file-abc123",
+              object: "vector_store.file.deleted",
+              deleted: true
+            }
+
+  /vector_stores/{vector_store_id}/file_batches:
+    post:
+      operationId: createVectorStoreFileBatch
+      tags:
+        - Vector Stores
+      summary: Create a vector store file batch.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: |
+            The ID of the vector store for which to create a File Batch.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVectorStoreFileBatchRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Create vector store file batch
+        group: vector_stores
+        beta: true
+        returns: A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/file_batches \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "file_ids": ["file-abc123", "file-abc456"]
+                  }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+                vector_store_id="vs_abc123",
+                file_ids=["file-abc123", "file-abc456"]
+              )
+              print(vector_store_file_batch)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const myVectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.create(
+                  "vs_abc123",
+                  {
+                    file_ids: ["file-abc123", "file-abc456"]
+                  }
+                );
+                console.log(myVectorStoreFileBatch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "in_progress",
+              "file_counts": {
+                "in_progress": 1,
+                "completed": 1,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 0,
+              }
+            }
+
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}:
+    get:
+      operationId: getVectorStoreFileBatch
+      tags:
+        - Vector Stores
+      summary: Retrieves a vector store file batch.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: The ID of the vector store that the file batch belongs to.
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+            example: vsfb_abc123
+          description: The ID of the file batch being retrieved.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Retrieve vector store file batch
+        group: vector_stores
+        beta: true
+        returns: The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_file_batch = client.beta.vector_stores.file_batches.retrieve(
+                vector_store_id="vs_abc123",
+                batch_id="vsfb_abc123"
+              )
+              print(vector_store_file_batch)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.retrieve(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(vectorStoreFileBatch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "in_progress",
+              "file_counts": {
+                "in_progress": 1,
+                "completed": 1,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 0,
+              }
+            }
+
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel:
+    post:
+      operationId: cancelVectorStoreFileBatch
+      tags:
+        - Vector Stores
+      summary: Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store that the file batch belongs to.
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file batch to cancel.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Cancel vector store file batch
+        group: vector_stores
+        beta: true
+        returns: The modified vector store file batch object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X POST
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_vector_store_file_batch = client.beta.vector_stores.file_batches.cancel(
+                  vector_store_id="vs_abc123",
+                  file_batch_id="vsfb_abc123"
+              )
+              print(deleted_vector_store_file_batch)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedVectorStoreFileBatch = await openai.vector_stores.fileBatches.cancel(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(deletedVectorStoreFileBatch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "cancelling",
+              "file_counts": {
+                "in_progress": 12,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 15,
+              }
+            }
+
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}/files:
+    get:
+      operationId: listFilesInVectorStoreBatch
+      tags:
+        - Vector Stores
+      summary: Returns a list of vector store files in a batch.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: The ID of the vector store that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: batch_id
+          in: path
+          description: The ID of the file batch that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: *pagination_limit_param_description
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: *pagination_order_param_description
+          schema:
+            type: string
+            default: desc
+            enum: ["asc", "desc"]
+        - name: after
+          in: query
+          description: *pagination_after_param_description
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: *pagination_before_param_description
+          schema:
+            type: string
+        - name: filter
+          in: query
+          description: "Filter by file status. One of `in_progress`, `completed`, `failed`, `cancelled`."
+          schema:
+            type: string
+            enum: ["in_progress", "completed", "failed", "cancelled"]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+      x-oaiMeta:
+        name: List vector store files in a batch
+        group: vector_stores
+        beta: true
+        returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_files = client.beta.vector_stores.file_batches.list_files(
+                vector_store_id="vs_abc123",
+                batch_id="vsfb_abc123"
+              )
+              print(vector_store_files)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStoreFiles = await openai.beta.vectorStores.fileBatches.listFiles(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(vectorStoreFiles);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "file-abc123",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                },
+                {
+                  "id": "file-abc456",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                }
+              ],
+              "first_id": "file-abc123",
+              "last_id": "file-abc456",
+              "has_more": false
+            }
+
+  /batches:
+    post:
+      summary: Creates and executes a batch from an uploaded file of requests
+      operationId: createBatch
+      tags:
+        - Batch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - input_file_id
+                - endpoint
+                - completion_window
+              properties:
+                input_file_id:
+                  type: string
+                  description: |
+                    The ID of an uploaded file that contains requests for the new batch.
+
+                    See [upload file](/docs/api-reference/files/create) for how to upload a file.
+
+                    Your input file must be formatted as a [JSONL file](/docs/api-reference/batch/requestInput), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 100 MB in size.
+                endpoint:
+                  type: string
+                  enum: ["/v1/chat/completions", "/v1/embeddings", "/v1/completions"]
+                  description: The endpoint to be used for all requests in the batch. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch.
+                completion_window:
+                  type: string
+                  enum: ["24h"]
+                  description: The time frame within which the batch should be processed. Currently only `24h` is supported.
+                metadata:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Optional custom metadata for the batch.
+                  nullable: true
+      responses:
+        "200":
+          description: Batch created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Create batch
+        group: batch
+        returns: The created [Batch](/docs/api-reference/batch/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "input_file_id": "file-abc123",
+                  "endpoint": "/v1/chat/completions",
+                  "completion_window": "24h"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.create(
+                input_file_id="file-abc123",
+                endpoint="/v1/chat/completions",
+                completion_window="24h"
+              )
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.create({
+                  input_file_id: "file-abc123",
+                  endpoint: "/v1/chat/completions",
+                  completion_window: "24h"
+                });
+
+                console.log(batch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/chat/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "validating",
+              "output_file_id": null,
+              "error_file_id": null,
+              "created_at": 1711471533,
+              "in_progress_at": null,
+              "expires_at": null,
+              "finalizing_at": null,
+              "completed_at": null,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": null,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 0,
+                "completed": 0,
+                "failed": 0
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
+            }
+    get:
+      operationId: listBatches
+      tags:
+        - Batch
+      summary: List your organization's batches.
+      parameters:
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+          description: *pagination_after_param_description
+        - name: limit
+          in: query
+          description: *pagination_limit_param_description
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: Batch listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListBatchesResponse"
+      x-oaiMeta:
+        name: List batch
+        group: batch
+        returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches?limit=2 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.list()
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.batches.list();
+
+                for await (const batch of list) {
+                  console.log(batch);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "batch_abc123",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "errors": null,
+                  "input_file_id": "file-abc123",
+                  "completion_window": "24h",
+                  "status": "completed",
+                  "output_file_id": "file-cvaTdG",
+                  "error_file_id": "file-HOWS94",
+                  "created_at": 1711471533,
+                  "in_progress_at": 1711471538,
+                  "expires_at": 1711557933,
+                  "finalizing_at": 1711493133,
+                  "completed_at": 1711493163,
+                  "failed_at": null,
+                  "expired_at": null,
+                  "cancelling_at": null,
+                  "cancelled_at": null,
+                  "request_counts": {
+                    "total": 100,
+                    "completed": 95,
+                    "failed": 5
+                  },
+                  "metadata": {
+                    "customer_id": "user_123456789",
+                    "batch_description": "Nightly job",
+                  }
+                },
+                { ... },
+              ],
+              "first_id": "batch_abc123",
+              "last_id": "batch_abc456",
+              "has_more": true
+            }
+
+  /batches/{batch_id}:
+    get:
+      operationId: retrieveBatch
+      tags:
+        - Batch
+      summary: Retrieves a batch.
+      parameters:
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the batch to retrieve.
+      responses:
+        "200":
+          description: Batch retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Retrieve batch
+        group: batch
+        returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches/batch_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.retrieve("batch_abc123")
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.retrieve("batch_abc123");
+
+                console.log(batch);
+              }
+
+              main();
+          response: &batch_object |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "completed",
+              "output_file_id": "file-cvaTdG",
+              "error_file_id": "file-HOWS94",
+              "created_at": 1711471533,
+              "in_progress_at": 1711471538,
+              "expires_at": 1711557933,
+              "finalizing_at": 1711493133,
+              "completed_at": 1711493163,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": null,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 100,
+                "completed": 95,
+                "failed": 5
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
+            }
+
+  /batches/{batch_id}/cancel:
+    post:
+      operationId: cancelBatch
+      tags:
+        - Batch
+      summary: Cancels an in-progress batch.
+      parameters:
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the batch to cancel.
+      responses:
+        "200":
+          description: Batch is cancelling. Returns the cancelling batch's details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Cancel batch
+        group: batch
+        returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches/batch_abc123/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -X POST
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.cancel("batch_abc123")
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.cancel("batch_abc123");
+
+                console.log(batch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/chat/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "cancelling",
+              "output_file_id": null,
+              "error_file_id": null,
+              "created_at": 1711471533,
+              "in_progress_at": 1711471538,
+              "expires_at": 1711557933,
+              "finalizing_at": null,
+              "completed_at": null,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": 1711475133,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 100,
+                "completed": 23,
+                "failed": 1
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
             }
 
 components:
@@ -5234,8 +7214,13 @@ components:
           type: boolean
           nullable: true
           default: false
+        stream_options:
+          $ref: "#/components/schemas/ChatCompletionStreamOptions"
         suffix:
-          description: The suffix that comes after a completion of inserted text.
+          description: |
+            The suffix that comes after a completion of inserted text.
+
+            This parameter is only supported for `gpt-3.5-turbo-instruct`.
           default: null
           nullable: true
           type: string
@@ -5355,7 +7340,7 @@ components:
             "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
             "object": "text_completion",
             "created": 1589478378,
-            "model": "gpt-3.5-turbo",
+            "model": "gpt-4-turbo",
             "choices": [
               {
                 "text": "\n\nThis is indeed a test",
@@ -5564,7 +7549,8 @@ components:
         name:
           type: string
           description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
-        parameters: {}
+        parameters:
+          $ref: "#/components/schemas/FunctionParameters"
       required:
         - name
 
@@ -5601,24 +7587,27 @@ components:
         name:
           type: string
           description: The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
-        parameters: {}
+        parameters:
+          $ref: "#/components/schemas/FunctionParameters"
       required:
         - name
 
     ChatCompletionToolChoiceOption:
       description: |
-        Controls which (if any) function is called by the model.
-        `none` means the model will not call a function and instead generates a message.
-        `auto` means the model can pick between generating a message or calling a function.
-        Specifying a particular function via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that function.
+        Controls which (if any) tool is called by the model.
+        `none` means the model will not call any tool and instead generates a message.
+        `auto` means the model can pick between generating a message or calling one or more tools.
+        `required` means the model must call one or more tools.
+        Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
 
-        `none` is the default when no functions are present. `auto` is the default if functions are present.
+        `none` is the default when no tools are present. `auto` is the default if tools are present.
       oneOf:
         - type: string
           description: >
-            `none` means the model will not call a function and instead generates a message.
-            `auto` means the model can pick between generating a message or calling a function.
-          enum: [none, auto]
+            `none` means the model will not call any tool and instead generates a message.
+            `auto` means the model can pick between generating a message or calling one or more tools.
+            `required` means the model must call one or more tools.
+          enum: [none, auto, required]
         - $ref: "#/components/schemas/ChatCompletionNamedToolChoice"
       x-oaiExpandable: true
 
@@ -5712,6 +7701,18 @@ components:
         - tool
         - function
 
+    ChatCompletionStreamOptions:
+      description: |
+        Options for streaming response. Only set this when you set `stream: true`.
+      type: object
+      nullable: true
+      default: null
+      properties:
+        include_usage:
+          type: boolean
+          description: |
+            If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value.
+
     ChatCompletionResponseMessage:
       type: object
       description: A chat completion message generated by the model.
@@ -5783,12 +7784,16 @@ components:
             $ref: "#/components/schemas/ChatCompletionRequestMessage"
         model:
           description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
-          example: "gpt-3.5-turbo"
+          example: "gpt-4-turbo"
           anyOf:
             - type: string
             - type: string
               enum:
                 [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
                   "gpt-4-0125-preview",
                   "gpt-4-turbo-preview",
                   "gpt-4-1106-preview",
@@ -5827,15 +7832,15 @@ components:
 
             Accepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
         logprobs:
-          description: Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`. This option is currently not available on the `gpt-4-vision-preview` model.
+          description: Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`.
           type: boolean
           default: false
           nullable: true
         top_logprobs:
-          description: An integer between 0 and 5 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.
+          description: An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.
           type: integer
           minimum: 0
-          maximum: 5
+          maximum: 20
           nullable: true
         max_tokens:
           description: |
@@ -5904,6 +7909,8 @@ components:
           type: boolean
           nullable: true
           default: false
+        stream_options:
+          $ref: "#/components/schemas/ChatCompletionStreamOptions"
         temperature:
           type: number
           minimum: 0
@@ -5924,7 +7931,7 @@ components:
           type: array
           description: >
             A list of tools the model may call. Currently, only functions are supported as a tool.
-            Use this to provide a list of functions the model may generate JSON inputs for.
+            Use this to provide a list of functions the model may generate JSON inputs for. A max of 128 functions are supported.
           items:
             $ref: "#/components/schemas/ChatCompletionTool"
         tool_choice:
@@ -6110,7 +8117,7 @@ components:
           description: The token.
           type: string
         logprob: &chat_completion_response_logprobs_token_logprob
-          description: The log probability of this token.
+          description: The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely.
           type: number
         bytes: &chat_completion_response_logprobs_bytes
           description: A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token.
@@ -6163,7 +8170,9 @@ components:
           description: A unique identifier for the chat completion. Each chunk has the same ID.
         choices:
           type: array
-          description: A list of chat completion choices. Can be more than one if `n` is greater than 1.
+          description: |
+            A list of chat completion choices. Can contain more than one elements if `n` is greater than 1. Can also be empty for the
+            last chunk if you set `stream_options: {"include_usage": true}`.
           items:
             type: object
             required:
@@ -6204,6 +8213,25 @@ components:
           type: string
           description: The object type, which is always `chat.completion.chunk`.
           enum: [chat.completion.chunk]
+        usage:
+          type: object
+          description: |
+            An optional field that will only be present when you set `stream_options: {"include_usage": true}` in your request.
+            When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+          properties:
+            completion_tokens:
+              type: integer
+              description: Number of tokens in the generated completion.
+            prompt_tokens:
+              type: integer
+              description: Number of tokens in the prompt.
+            total_tokens:
+              type: integer
+              description: Total number of tokens used in the request (prompt + completion).
+          required:
+            - prompt_tokens
+            - completion_tokens
+            - total_tokens
       required:
         - choices
         - created
@@ -6260,7 +8288,7 @@ components:
           default: "url"
           example: "url"
           nullable: true
-          description: The format in which the generated images are returned. Must be one of `url` or `b64_json`.
+          description: The format in which the generated images are returned. Must be one of `url` or `b64_json`. URLs are only valid for 60 minutes after the image has been generated.
         size: &images_size
           type: string
           enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
@@ -6414,7 +8442,7 @@ components:
 
     CreateModerationResponse:
       type: object
-      description: Represents policy compliance report by OpenAI's content moderation model against a given input.
+      description: Represents if a given text input is potentially harmful.
       properties:
         id:
           type: string
@@ -6430,7 +8458,7 @@ components:
             properties:
               flagged:
                 type: boolean
-                description: Whether the content violates [OpenAI's usage policies](/policies/usage-policies).
+                description: Whether any of the below categories are flagged.
               categories:
                 type: object
                 description: A list of the categories, and whether they are flagged or not.
@@ -6568,9 +8596,9 @@ components:
           description: |
             The intended purpose of the uploaded file.
 
-            Use "fine-tune" for [Fine-tuning](/docs/api-reference/fine-tuning) and "assistants" for [Assistants](/docs/api-reference/assistants) and [Messages](/docs/api-reference/messages). This allows us to validate the format of the uploaded file is correct for fine-tuning.
+            Use "assistants" for [Assistants](/docs/api-reference/assistants) and [Message](/docs/api-reference/messages) files, "vision" for Assistants image file inputs, "batch" for [Batch API](/docs/guides/batch), and "fine-tune" for [Fine-tuning](/docs/api-reference/fine-tuning).
           type: string
-          enum: ["fine-tune", "assistants"]
+          enum: ["assistants", "batch", "fine-tune", "vision", "foobar"]
       required:
         - file
         - purpose
@@ -6607,7 +8635,7 @@ components:
           description: |
             The ID of an uploaded file that contains training data.
 
-            See [upload file](/docs/api-reference/files/upload) for how to upload a file.
+            See [upload file](/docs/api-reference/files/create) for how to upload a file.
 
             Your dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.
 
@@ -6676,6 +8704,65 @@ components:
           type: string
           nullable: true
           example: "file-abc123"
+        integrations:
+          type: array
+          description: A list of integrations to enable for your fine-tuning job.
+          nullable: true
+          items:
+            type: object
+            required:
+              - type
+              - wandb
+            properties:
+              type:
+                description: |
+                  The type of integration to enable. Currently, only "wandb" (Weights and Biases) is supported.
+                oneOf:
+                  - type: string
+                    enum: [wandb]
+              wandb:
+                type: object
+                description: |
+                  The settings for your integration with Weights and Biases. This payload specifies the project that
+                  metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+                  to your run, and set a default entity (team, username, etc) to be associated with your run.
+                required:
+                  - project
+                properties:
+                  project:
+                    description: |
+                      The name of the project that the new run will be created under.
+                    type: string
+                    example: "my-wandb-project"
+                  name:
+                    description: |
+                      A display name to set for the run. If not set, we will use the Job ID as the name.
+                    nullable: true
+                    type: string
+                  entity:
+                    description: |
+                      The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                      like associated with the run. If not set, the default entity for the registered WandB API key is used.
+                    nullable: true
+                    type: string
+                  tags:
+                    description: |
+                      A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                      default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+                    type: array
+                    items:
+                      type: string
+                      example: "custom-tag"
+
+        seed:
+          description: |
+            The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.
+            If a seed is not specified, one will be generated for you.
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 2147483647
+          example: 42
       required:
         - model
         - training_file
@@ -6693,6 +8780,29 @@ components:
       required:
         - object
         - data
+
+    ListFineTuningJobCheckpointsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FineTuningJobCheckpoint"
+        object:
+          type: string
+          enum: [list]
+        first_id:
+          type: string
+          nullable: true
+        last_id:
+          type: string
+          nullable: true
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - has_more
 
     CreateEmbeddingRequest:
       type: object
@@ -6743,7 +8853,12 @@ components:
           anyOf:
             - type: string
             - type: string
-              enum: ["text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large"]
+              enum:
+                [
+                  "text-embedding-ada-002",
+                  "text-embedding-3-small",
+                  "text-embedding-3-large",
+                ]
           x-oaiTypeLabel: string
         encoding_format:
           description: "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/)."
@@ -6807,7 +8922,7 @@ components:
           format: binary
         model:
           description: |
-            ID of the model to use. Only `whisper-1` is currently available.
+            ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
           example: whisper-1
           anyOf:
             - type: string
@@ -6840,7 +8955,7 @@ components:
           default: 0
         timestamp_granularities[]:
           description: |
-            The timestamp granularities to populate for this transcription. Any of these options: `word`, or `segment`. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.
+            The timestamp granularities to populate for this transcription. `response_format` must be set `verbose_json` to use timestamp granularities. Either or both of these options are supported: `word`, or `segment`. Note: There is no additional latency for segment timestamps, but generating word timestamps incurs additional latency.
           type: array
           items:
             type: string
@@ -6853,13 +8968,117 @@ components:
         - model
 
     # Note: This does not currently support the non-default response format types.
-    CreateTranscriptionResponse:
+    CreateTranscriptionResponseJson:
       type: object
+      description: Represents a transcription response returned by model, based on the provided input.
       properties:
         text:
           type: string
+          description: The transcribed text.
       required:
         - text
+      x-oaiMeta:
+        name: The transcription object
+        group: audio
+        example: *basic_transcription_response_example
+
+    TranscriptionSegment:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique identifier of the segment.
+        seek:
+          type: integer
+          description: Seek offset of the segment.
+        start:
+          type: number
+          format: float
+          description: Start time of the segment in seconds.
+        end:
+          type: number
+          format: float
+          description: End time of the segment in seconds.
+        text:
+          type: string
+          description: Text content of the segment.
+        tokens:
+          type: array
+          items:
+            type: integer
+          description: Array of token IDs for the text content.
+        temperature:
+          type: number
+          format: float
+          description: Temperature parameter used for generating the segment.
+        avg_logprob:
+          type: number
+          format: float
+          description: Average logprob of the segment. If the value is lower than -1, consider the logprobs failed.
+        compression_ratio:
+          type: number
+          format: float
+          description: Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed.
+        no_speech_prob:
+          type: number
+          format: float
+          description: Probability of no speech in the segment. If the value is higher than 1.0 and the `avg_logprob` is below -1, consider this segment silent.
+      required:
+        - id
+        - seek
+        - start
+        - end
+        - text
+        - tokens
+        - temperature
+        - avg_logprob
+        - compression_ratio
+        - no_speech_prob
+
+    TranscriptionWord:
+      type: object
+      properties:
+        word:
+          type: string
+          description: The text content of the word.
+        start:
+          type: number
+          format: float
+          description: Start time of the word in seconds.
+        end:
+          type: number
+          format: float
+          description: End time of the word in seconds.
+      required: [word, start, end]
+
+    CreateTranscriptionResponseVerboseJson:
+      type: object
+      description: Represents a verbose json transcription response returned by model, based on the provided input.
+      properties:
+        language:
+          type: string
+          description: The language of the input audio.
+        duration:
+          type: string
+          description: The duration of the input audio.
+        text:
+          type: string
+          description: The transcribed text.
+        words:
+          type: array
+          description: Extracted words and their corresponding timestamps.
+          items:
+            $ref: "#/components/schemas/TranscriptionWord"
+        segments:
+          type: array
+          description: Segments of the transcribed text and their corresponding details.
+          items:
+            $ref: "#/components/schemas/TranscriptionSegment"
+      required: [language, duration, text]
+      x-oaiMeta:
+        name: The transcription object
+        group: audio
+        example: *verbose_transcription_response_example
 
     CreateTranslationRequest:
       type: object
@@ -6873,7 +9092,7 @@ components:
           format: binary
         model:
           description: |
-            ID of the model to use. Only `whisper-1` is currently available.
+            ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
           example: whisper-1
           anyOf:
             - type: string
@@ -6899,13 +9118,32 @@ components:
         - model
 
     # Note: This does not currently support the non-default response format types.
-    CreateTranslationResponse:
+    CreateTranslationResponseJson:
       type: object
       properties:
         text:
           type: string
       required:
         - text
+
+    CreateTranslationResponseVerboseJson:
+      type: object
+      properties:
+        language:
+          type: string
+          description: The language of the output translation (always `english`).
+        duration:
+          type: string
+          description: The duration of the input audio.
+        text:
+          type: string
+          description: The translated text.
+        segments:
+          type: array
+          description: Segments of the translated text and their corresponding details.
+          items:
+            $ref: "#/components/schemas/TranscriptionSegment"
+      required: [language, duration, text]
 
     CreateSpeechRequest:
       type: object
@@ -6928,10 +9166,10 @@ components:
           type: string
           enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
         response_format:
-          description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, and `flac`."
+          description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
           default: "mp3"
           type: string
-          enum: ["mp3", "opus", "aac", "flac"]
+          enum: ["mp3", "opus", "aac", "flac", "wav", "pcm"]
         speed:
           description: "The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default."
           type: number
@@ -6991,13 +9229,16 @@ components:
           enum: ["file"]
         purpose:
           type: string
-          description: The intended purpose of the file. Supported values are `fine-tune`, `fine-tune-results`, `assistants`, and `assistants_output`.
+          description: The intended purpose of the file. Supported values are `assistants`, `assistants_output`, `batch`, `batch_output`, `fine-tune`, `fine-tune-results` and `vision`.
           enum:
             [
-              "fine-tune",
-              "fine-tune-results",
               "assistants",
               "assistants_output",
+              "batch",
+              "batch_output",
+              "fine-tune",
+              "fine-tune-results",
+              "vision"
             ]
         status:
           type: string
@@ -7159,6 +9400,22 @@ components:
           type: string
           nullable: true
           description: The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).
+        integrations:
+          type: array
+          nullable: true
+          description: A list of integrations to enable for this fine-tuning job.
+          maxItems: 5
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/FineTuningIntegration"
+            x-oaiExpandable: true
+        seed:
+          type: integer
+          description: The seed used for the fine-tuning job.
+        estimated_finish:
+          type: integer
+          nullable: true
+          description: The Unix timestamp (in seconds) for when the fine-tuning job is estimated to finish. The value will be null if the fine-tuning job is not running.
       required:
         - created_at
         - error
@@ -7174,9 +9431,55 @@ components:
         - trained_tokens
         - training_file
         - validation_file
+        - seed
       x-oaiMeta:
         name: The fine-tuning job object
         example: *fine_tuning_example
+
+    FineTuningIntegration:
+      type: object
+      title: Fine-Tuning Job Integration
+      required:
+        - type
+        - wandb
+      properties:
+        type:
+          type: string
+          description: "The type of the integration being enabled for the fine-tuning job"
+          enum: ["wandb"]
+        wandb:
+          type: object
+          description: |
+            The settings for your integration with Weights and Biases. This payload specifies the project that
+            metrics will be sent to. Optionally, you can set an explicit display name for your run, add tags
+            to your run, and set a default entity (team, username, etc) to be associated with your run.
+          required:
+            - project
+          properties:
+            project:
+              description: |
+                The name of the project that the new run will be created under.
+              type: string
+              example: "my-wandb-project"
+            name:
+              description: |
+                A display name to set for the run. If not set, we will use the Job ID as the name.
+              nullable: true
+              type: string
+            entity:
+              description: |
+                The entity to use for the run. This allows you to set the team or username of the WandB user that you would
+                like associated with the run. If not set, the default entity for the registered WandB API key is used.
+              nullable: true
+              type: string
+            tags:
+              description: |
+                A list of tags to be attached to the newly created run. These tags are passed through directly to WandB. Some
+                default tags are generated by OpenAI: "openai/finetune", "openai/{base-model}", "openai/{ftjob-abcdef}".
+              type: array
+              items:
+                type: string
+                example: "custom-tag"
 
     FineTuningJobEvent:
       type: object
@@ -7209,6 +9512,78 @@ components:
             "created_at": 1677610602,
             "level": "info",
             "message": "Created fine-tuning job"
+          }
+
+    FineTuningJobCheckpoint:
+      type: object
+      title: FineTuningJobCheckpoint
+      description: |
+        The `fine_tuning.job.checkpoint` object represents a model checkpoint for a fine-tuning job that is ready to use.
+      properties:
+        id:
+          type: string
+          description: The checkpoint identifier, which can be referenced in the API endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the checkpoint was created.
+        fine_tuned_model_checkpoint:
+          type: string
+          description: The name of the fine-tuned checkpoint model that is created.
+        step_number:
+          type: integer
+          description: The step number that the checkpoint was created at.
+        metrics:
+          type: object
+          description: Metrics at the step number during the fine-tuning job.
+          properties:
+            step:
+              type: number
+            train_loss:
+              type: number
+            train_mean_token_accuracy:
+              type: number
+            valid_loss:
+              type: number
+            valid_mean_token_accuracy:
+              type: number
+            full_valid_loss:
+              type: number
+            full_valid_mean_token_accuracy:
+              type: number
+        fine_tuning_job_id:
+          type: string
+          description: The name of the fine-tuning job that this checkpoint was created from.
+        object:
+          type: string
+          description: The object type, which is always "fine_tuning.job.checkpoint".
+          enum: [fine_tuning.job.checkpoint]
+      required:
+        - created_at
+        - fine_tuning_job_id
+        - fine_tuned_model_checkpoint
+        - id
+        - metrics
+        - object
+        - step_number
+      x-oaiMeta:
+        name: The fine-tuning job checkpoint object
+        example: |
+          {
+            "object": "fine_tuning.job.checkpoint",
+            "id": "ftckpt_qtZ5Gyk4BLq1SfLFWp3RtO3P",
+            "created_at": 1712211699,
+            "fine_tuned_model_checkpoint": "ft:gpt-3.5-turbo-0125:my-org:custom_suffix:9ABel2dg:ckpt-step-88",
+            "fine_tuning_job_id": "ftjob-fpbNQ3H1GrMehXRf8cO97xTN",
+            "metrics": {
+              "step": 88,
+              "train_loss": 0.478,
+              "train_mean_token_accuracy": 0.924,
+              "valid_loss": 10.112,
+              "valid_mean_token_accuracy": 0.145,
+              "full_valid_loss": 0.567,
+              "full_valid_mean_token_accuracy": 0.944
+            },
+            "step_number": 88
           }
 
     CompletionUsage:
@@ -7267,6 +9642,33 @@ components:
         - total_tokens
       nullable: true
 
+    AssistantsApiResponseFormatOption:
+      description: |
+        Specifies the format that the model must output. Compatible with [GPT-4o](/docs/models/gpt-4o), [GPT-4 Turbo](/docs/models/gpt-4-turbo-and-gpt-4), and all GPT-3.5 Turbo models since `gpt-3.5-turbo-1106`.
+
+        Setting to `{ "type": "json_object" }` enables JSON mode, which guarantees the message the model generates is valid JSON.
+
+        **Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length.
+      oneOf:
+        - type: string
+          description: >
+            `auto` is the default value
+          enum: [none, auto]
+        - $ref: "#/components/schemas/AssistantsApiResponseFormat"
+      x-oaiExpandable: true
+
+    AssistantsApiResponseFormat:
+      type: object
+      description: |
+        An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run. If `text` the model can return text or any value needed.
+      properties:
+        type:
+          type: string
+          enum: ["text", "json_object"]
+          example: "json_object"
+          default: "text"
+          description: Must be one of `text` or `json_object`.
+
     AssistantObject:
       type: object
       title: Assistant
@@ -7299,35 +9701,77 @@ components:
           type: string
         instructions:
           description: &assistant_instructions_param_description |
-            The system instructions that the assistant uses. The maximum length is 32768 characters.
+            The system instructions that the assistant uses. The maximum length is 256,000 characters.
           type: string
-          maxLength: 32768
+          maxLength: 256000
           nullable: true
         tools:
           description: &assistant_tools_param_description |
-            A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `retrieval`, or `function`.
+            A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.
           default: []
           type: array
           maxItems: 128
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
             x-oaiExpandable: true
-        file_ids:
-          description: &assistant_file_param_description |
-            A list of [file](/docs/api-reference/files) IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant. Files are ordered by their creation date in ascending order.
-          default: []
-          type: array
-          maxItems: 20
-          items:
-            type: string
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter`` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
         metadata:
           description: &metadata_description |
             Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
           type: object
           x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: &run_temperature_description |
+            What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: &run_top_p_description |
+            An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
         - id
@@ -7338,7 +9782,6 @@ components:
         - model
         - instructions
         - tools
-        - file_ids
         - metadata
       x-oaiMeta:
         name: The assistant object
@@ -7351,8 +9794,34 @@ components:
       properties:
         model:
           description: *model_description
+          example: "gpt-4-turbo"
           anyOf:
             - type: string
+            - type: string
+              enum:
+                [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613",
+                ]
+          x-oaiTypeLabel: string
         name:
           description: *assistant_name_param_description
           type: string
@@ -7367,7 +9836,7 @@ components:
           description: *assistant_instructions_param_description
           type: string
           nullable: true
-          maxLength: 32768
+          maxLength: 256000
         tools:
           description: *assistant_tools_param_description
           default: []
@@ -7376,20 +9845,86 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
             x-oaiExpandable: true
-        file_ids:
-          description: *assistant_file_param_description
-          default: []
-          maxItems: 20
-          type: array
-          items:
-            type: string
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+                vector_stores:
+                  type: array
+                  description: |
+                    A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      file_ids:
+                        type: array
+                        description: |
+                          A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                        maxItems: 10000
+                        items:
+                          type: string
+                      metadata:
+                        type: object
+                        description: |
+                          Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                        x-oaiTypeLabel: map
+              oneOf:
+                - required: [vector_store_ids]
+                - required: [vector_stores]
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
           x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: &run_temperature_description |
+            What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: &run_top_p_description |
+            An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
         - model
@@ -7416,7 +9951,7 @@ components:
           description: *assistant_instructions_param_description
           type: string
           nullable: true
-          maxLength: 32768
+          maxLength: 256000
         tools:
           description: *assistant_tools_param_description
           default: []
@@ -7425,21 +9960,62 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
             x-oaiExpandable: true
-        file_ids:
+        tool_resources:
+          type: object
           description: |
-            A list of [File](/docs/api-reference/files) IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant. Files are ordered by their creation date in ascending order. If a file was previously attached to the list but does not show up in the list, it will be deleted from the assistant.
-          default: []
-          type: array
-          maxItems: 20
-          items:
-            type: string
+            A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    Overrides the list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    Overrides the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
           x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: *run_temperature_description
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: &run_top_p_description |
+            An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
 
     DeleteAssistantResponse:
@@ -7498,14 +10074,14 @@ components:
       required:
         - type
 
-    AssistantToolsRetrieval:
+    AssistantToolsFileSearch:
       type: object
-      title: Retrieval tool
+      title: FileSearch tool
       properties:
         type:
           type: string
-          description: "The type of tool being defined: `retrieval`"
-          enum: ["retrieval"]
+          description: "The type of tool being defined: `file_search`"
+          enum: ["file_search"]
       required:
         - type
 
@@ -7522,6 +10098,60 @@ components:
       required:
         - type
         - function
+
+    TruncationObject:
+      type: object
+      title: Thread Truncation Controls
+      description: Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+      properties:
+        type:
+          type: string
+          description: The truncation strategy to use for the thread. The default is `auto`. If set to `last_messages`, the thread will be truncated to the n most recent messages in the thread. When set to `auto`, messages in the middle of the thread will be dropped to fit the context length of the model, `max_prompt_tokens`.
+          enum: ["auto", "last_messages"]
+        last_messages:
+          type: integer
+          description: The number of most recent messages from the thread when constructing the context for the run.
+          minimum: 1
+          nullable: true
+      required:
+        - type
+
+    AssistantsApiToolChoiceOption:
+      description: |
+        Controls which (if any) tool is called by the model.
+        `none` means the model will not call any tools and instead generates a message.
+        `auto` is the default value and means the model can pick between generating a message or calling one or more tools.
+        `required` means the model must call one or more tools before responding to the user.
+        Specifying a particular tool like `{"type": "file_search"}` or `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool.
+
+      oneOf:
+        - type: string
+          description: >
+            `none` means the model will not call any tools and instead generates a message.
+            `auto` means the model can pick between generating a message or calling one or more tools.
+            `required` means the model must call one or more tools before responding to the user.
+          enum: [none, auto, required]
+        - $ref: "#/components/schemas/AssistantsNamedToolChoice"
+      x-oaiExpandable: true
+
+    AssistantsNamedToolChoice:
+      type: object
+      description: Specifies a tool the model should use. Use to force the model to call a specific tool.
+      properties:
+        type:
+          type: string
+          enum: ["function", "code_interpreter", "file_search"]
+          description: The type of the tool. If type is `function`, the function name must be set
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - name
+      required:
+        - type
 
     RunObject:
       type: object
@@ -7545,7 +10175,7 @@ components:
           description: The ID of the [assistant](/docs/api-reference/assistants) used for execution of this run.
           type: string
         status:
-          description: The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, or `expired`.
+          description: The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, `incomplete`, or `expired`.
           type: string
           enum:
             [
@@ -7556,6 +10186,7 @@ components:
               "cancelled",
               "failed",
               "completed",
+              "incomplete",
               "expired",
             ]
         required_action:
@@ -7588,8 +10219,8 @@ components:
           properties:
             code:
               type: string
-              description: One of `server_error` or `rate_limit_exceeded`.
-              enum: ["server_error", "rate_limit_exceeded"]
+              description: One of `server_error`, `rate_limit_exceeded`, or `invalid_prompt`.
+              enum: ["server_error", "rate_limit_exceeded", "invalid_prompt"]
             message:
               type: string
               description: A human-readable description of the error.
@@ -7599,6 +10230,7 @@ components:
         expires_at:
           description: The Unix timestamp (in seconds) for when the run will expire.
           type: integer
+          nullable: true
         started_at:
           description: The Unix timestamp (in seconds) for when the run was started.
           type: integer
@@ -7615,6 +10247,15 @@ components:
           description: The Unix timestamp (in seconds) for when the run was completed.
           type: integer
           nullable: true
+        incomplete_details:
+          description: Details on why the run is incomplete. Will be `null` if the run is not incomplete.
+          type: object
+          nullable: true
+          properties:
+            reason:
+              description: The reason why the run is incomplete. This will point to which specific token limit was reached over the course of the run.
+              type: string
+              enum: ["max_completion_tokens", "max_prompt_tokens"]
         model:
           description: The model that the [assistant](/docs/api-reference/assistants) used for this run.
           type: string
@@ -7629,15 +10270,9 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
             x-oaiExpandable: true
-        file_ids:
-          description: The list of [File](/docs/api-reference/files) IDs the [assistant](/docs/api-reference/assistants) used for this run.
-          default: []
-          type: array
-          items:
-            type: string
         metadata:
           description: *metadata_description
           type: object
@@ -7645,6 +10280,35 @@ components:
           nullable: true
         usage:
           $ref: "#/components/schemas/RunCompletionUsage"
+        temperature:
+          description: The sampling temperature used for this run. If not set, defaults to 1.
+          type: number
+          nullable: true
+        top_p:
+          description: The nucleus sampling value used for this run. If not set, defaults to 1.
+          type: number
+          nullable: true
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of prompt tokens specified to have been used over the course of the run.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of completion tokens specified to have been used over the course of the run.
+          minimum: 256
+        truncation_strategy:
+          $ref: "#/components/schemas/TruncationObject"
+          nullable: true
+        tool_choice:
+          $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+          nullable: true
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+          nullable: true
       required:
         - id
         - object
@@ -7662,9 +10326,14 @@ components:
         - model
         - instructions
         - tools
-        - file_ids
         - metadata
         - usage
+        - incomplete_details
+        - max_prompt_tokens
+        - max_completion_tokens
+        - truncation_strategy
+        - tool_choice
+        - response_format
       x-oaiMeta:
         name: The run object
         beta: true
@@ -7682,16 +10351,26 @@ components:
             "failed_at": null,
             "completed_at": 1699073498,
             "last_error": null,
-            "model": "gpt-4",
+            "model": "gpt-4-turbo",
             "instructions": null,
-            "tools": [{"type": "retrieval"}, {"type": "code_interpreter"}],
-            "file_ids": [],
+            "tools": [{"type": "file_search"}, {"type": "code_interpreter"}],
             "metadata": {},
+            "incomplete_details": null,
             "usage": {
               "prompt_tokens": 123,
               "completion_tokens": 456,
               "total_tokens": 579
-            }
+            },
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "max_prompt_tokens": 1000,
+            "max_completion_tokens": 1000,
+            "truncation_strategy": {
+              "type": "auto",
+              "last_messages": null
+            },
+            "response_format": "auto",
+            "tool_choice": "auto"
           }
     CreateRunRequest:
       type: object
@@ -7702,7 +10381,34 @@ components:
           type: string
         model:
           description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
-          type: string
+          example: "gpt-4-turbo"
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613",
+                ]
+          x-oaiTypeLabel: string
           nullable: true
         instructions:
           description: Overrides the [instructions](/docs/api-reference/assistants/createAssistant) of the assistant. This is useful for modifying the behavior on a per-run basis.
@@ -7712,6 +10418,12 @@ components:
           description: Appends additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.
           type: string
           nullable: true
+        additional_messages:
+          description: Adds additional messages to the thread before creating the run.
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateMessageRequest"
+          nullable: true
         tools:
           description: Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.
           nullable: true
@@ -7720,13 +10432,58 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
             x-oaiExpandable: true
         metadata:
           description: *metadata_description
           type: object
           x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: *run_temperature_description
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: &run_top_p_description |
+            An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+            We generally recommend altering this or temperature but not both.
+        stream:
+          type: boolean
+          nullable: true
+          description: |
+            If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        truncation_strategy:
+          $ref: "#/components/schemas/TruncationObject"
+          nullable: true
+        tool_choice:
+          $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+          nullable: true
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
         - thread_id
@@ -7781,6 +10538,11 @@ components:
               output:
                 type: string
                 description: The output of the tool call to be submitted to continue the run.
+        stream:
+          type: boolean
+          nullable: true
+          description: |
+            If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
       required:
         - tool_outputs
 
@@ -7825,7 +10587,34 @@ components:
           description: If no thread is provided, an empty thread will be created.
         model:
           description: The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.
-          type: string
+          example: "gpt-4-turbo"
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                [
+                  "gpt-4o",
+                  "gpt-4o-2024-05-13",
+                  "gpt-4-turbo",
+                  "gpt-4-turbo-2024-04-09",
+                  "gpt-4-0125-preview",
+                  "gpt-4-turbo-preview",
+                  "gpt-4-1106-preview",
+                  "gpt-4-vision-preview",
+                  "gpt-4",
+                  "gpt-4-0314",
+                  "gpt-4-0613",
+                  "gpt-4-32k",
+                  "gpt-4-32k-0314",
+                  "gpt-4-32k-0613",
+                  "gpt-3.5-turbo",
+                  "gpt-3.5-turbo-16k",
+                  "gpt-3.5-turbo-0613",
+                  "gpt-3.5-turbo-1106",
+                  "gpt-3.5-turbo-0125",
+                  "gpt-3.5-turbo-16k-0613",
+                ]
+          x-oaiTypeLabel: string
           nullable: true
         instructions:
           description: Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.
@@ -7839,12 +10628,81 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/AssistantToolsCode"
-              - $ref: "#/components/schemas/AssistantToolsRetrieval"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
               - $ref: "#/components/schemas/AssistantToolsFunction"
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are used by the assistant's tools. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The ID of the [vector store](/docs/api-reference/vector-stores/object) attached to this assistant. There can be a maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
           x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: *run_temperature_description
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: *run_top_p_description
+        stream:
+          type: boolean
+          nullable: true
+          description: |
+            If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only the number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: |
+            The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        truncation_strategy:
+          $ref: "#/components/schemas/TruncationObject"
+          nullable: true
+        tool_choice:
+          $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+          nullable: true
+        response_format:
+          $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
         - thread_id
@@ -7865,6 +10723,33 @@ components:
         created_at:
           description: The Unix timestamp (in seconds) for when the thread was created.
           type: integer
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
@@ -7874,6 +10759,7 @@ components:
         - id
         - object
         - created_at
+        - tool_resources
         - metadata
       x-oaiMeta:
         name: The thread object
@@ -7895,6 +10781,56 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CreateMessageRequest"
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+                vector_stores:
+                  type: array
+                  description: |
+                    A helper to create a [vector store](/docs/api-reference/vector-stores/object) with file_ids and attach it to this thread. There can be a maximum of 1 vector store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      file_ids:
+                        type: array
+                        description: |
+                          A list of [file](/docs/api-reference/files) IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.
+                        maxItems: 10000
+                        items:
+                          type: string
+                      metadata:
+                        type: object
+                        description: |
+                          Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                        x-oaiTypeLabel: map
+              oneOf:
+                - required: [vector_store_ids]
+                - required: [vector_stores]
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
@@ -7905,6 +10841,33 @@ components:
       type: object
       additionalProperties: false
       properties:
+        tool_resources:
+          type: object
+          description: |
+            A set of resources that are made available to the assistant's tools in this thread. The resources are specific to the type of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: |
+                    A list of [file](/docs/api-reference/files) IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: |
+                    The [vector store](/docs/api-reference/vector-stores/object) attached to this thread. There can be a maximum of 1 vector store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
@@ -7969,6 +10932,36 @@ components:
         thread_id:
           description: The [thread](/docs/api-reference/threads) ID that this message belongs to.
           type: string
+        status:
+          description: The status of the message, which can be either `in_progress`, `incomplete`, or `completed`.
+          type: string
+          enum: ["in_progress", "incomplete", "completed"]
+        incomplete_details:
+          description: On an incomplete message, details about why the message is incomplete.
+          type: object
+          properties:
+            reason:
+              type: string
+              description: The reason the message is incomplete.
+              enum:
+                [
+                  "content_filter",
+                  "max_tokens",
+                  "run_cancelled",
+                  "run_expired",
+                  "run_failed",
+                ]
+          nullable: true
+          required:
+            - reason
+        completed_at:
+          description: The Unix timestamp (in seconds) for when the message was completed.
+          type: integer
+          nullable: true
+        incomplete_at:
+          description: The Unix timestamp (in seconds) for when the message was marked as incomplete.
+          type: integer
+          nullable: true
         role:
           description: The entity that produced the message. One of `user` or `assistant`.
           type: string
@@ -7979,6 +10972,7 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/MessageContentImageFileObject"
+              - $ref: "#/components/schemas/MessageContentImageUrlObject"
               - $ref: "#/components/schemas/MessageContentTextObject"
             x-oaiExpandable: true
         assistant_id:
@@ -7986,16 +10980,27 @@ components:
           type: string
           nullable: true
         run_id:
-          description: If applicable, the ID of the [run](/docs/api-reference/runs) associated with the authoring of this message.
+          description: The ID of the [run](/docs/api-reference/runs) associated with the creation of this message. Value is `null` when messages are created manually using the create message or create thread endpoints.
           type: string
           nullable: true
-        file_ids:
-          description: A list of [file](/docs/api-reference/files) IDs that the assistant should use. Useful for tools like retrieval and code_interpreter that can access files. A maximum of 10 files can be attached to a message.
-          default: []
-          maxItems: 10
+        attachments:
           type: array
           items:
-            type: string
+            type: object
+            properties:
+              file_id:
+                type: string
+                description: The ID of the file to attach to the message.
+              tools:
+                description: The tools to add this file to.
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/AssistantToolsCode"
+                    - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                  x-oaiExpandable: true
+          description: A list of files attached to the message, and the tools they were added to.
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
@@ -8006,11 +11011,15 @@ components:
         - object
         - created_at
         - thread_id
+        - status
+        - incomplete_details
+        - completed_at
+        - incomplete_at
         - role
         - content
         - assistant_id
         - run_id
-        - file_ids
+        - attachments
         - metadata
       x-oaiMeta:
         name: The message object
@@ -8031,10 +11040,62 @@ components:
                 }
               }
             ],
-            "file_ids": [],
             "assistant_id": "asst_abc123",
             "run_id": "run_abc123",
+            "attachments": [],
             "metadata": {}
+          }
+
+    MessageDeltaObject:
+      type: object
+      title: Message delta object
+      description: |
+        Represents a message delta i.e. any changed fields on a message during streaming.
+      properties:
+        id:
+          description: The identifier of the message, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.message.delta`.
+          type: string
+          enum: ["thread.message.delta"]
+        delta:
+          description: The delta containing the fields that have changed on the Message.
+          type: object
+          properties:
+            role:
+              description: The entity that produced the message. One of `user` or `assistant`.
+              type: string
+              enum: ["user", "assistant"]
+            content:
+              description: The content of the message in array of text and/or images.
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageDeltaContentImageFileObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentTextObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentImageUrlObject"
+                x-oaiExpandable: true
+      required:
+        - id
+        - object
+        - delta
+      x-oaiMeta:
+        name: The message delta object
+        beta: true
+        example: |
+          {
+            "id": "msg_123",
+            "object": "thread.message.delta",
+            "delta": {
+              "content": [
+                {
+                  "index": 0,
+                  "type": "text",
+                  "text": { "value": "Hello", "annotations": [] }
+                }
+              ]
+            }
           }
 
     CreateMessageRequest:
@@ -8046,21 +11107,48 @@ components:
       properties:
         role:
           type: string
-          enum: ["user"]
-          description: The role of the entity that is creating the message. Currently only `user` is supported.
+          enum: ["user", "assistant"]
+          description: |
+            The role of the entity that is creating the message. Allowed values include:
+            - `user`: Indicates the message is sent by an actual user and should be used in most cases to represent user-generated messages.
+            - `assistant`: Indicates the message is generated by the assistant. Use this value to insert messages from the assistant into the conversation.
         content:
-          type: string
-          minLength: 1
-          maxLength: 32768
-          description: The content of the message.
-        file_ids:
-          description: A list of [File](/docs/api-reference/files) IDs that the message should use. There can be a maximum of 10 files attached to a message. Useful for tools like `retrieval` and `code_interpreter` that can access and use files.
-          default: []
+          oneOf:
+              - type: string
+                description: The text contents of the message.
+                title: Text content
+              - type: array
+                description: An array of content parts with a defined type, each can be of type `text` or images can be passed with `image_url` or `image_file`. Image types are only supported on [Vision-compatible models](/docs/models/overview).
+                title: Array of content parts
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/MessageContentImageFileObject"
+                    - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                    - $ref: "#/components/schemas/MessageRequestContentTextObject"
+                  x-oaiExpandable: true
+                minItems: 1
+          x-oaiExpandable: true
+        attachments:
           type: array
-          minItems: 1
-          maxItems: 10
           items:
-            type: string
+            type: object
+            properties:
+              file_id:
+                type: string
+                description: The ID of the file to attach to the message.
+              tools:
+                description: The tools to add this file to.
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/AssistantToolsCode"
+                    - $ref: "#/components/schemas/AssistantToolsFileSearch"
+                  x-oaiExpandable: true
+          description: A list of files attached to the message, and the tools they should be added to.
+          required:
+            - file_id
+            - tools
+          nullable: true
         metadata:
           description: *metadata_description
           type: object
@@ -8130,13 +11218,99 @@ components:
           type: object
           properties:
             file_id:
-              description: The [File](/docs/api-reference/files) ID of the image in the message content.
+              description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
               type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+              enum: ["auto", "low", "high"]
+              default: "auto"
           required:
             - file_id
       required:
         - type
         - image_file
+
+    MessageDeltaContentImageFileObject:
+      title: Image file
+      type: object
+      description: References an image [File](/docs/api-reference/files) in the content of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `image_file`.
+          type: string
+          enum: ["image_file"]
+        image_file:
+          type: object
+          properties:
+            file_id:
+              description: The [File](/docs/api-reference/files) ID of the image in the message content. Set `purpose="vision"` when uploading the File if you need to later display the file content.
+              type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image if specified by the user. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+              enum: ["auto", "low", "high"]
+              default: "auto"
+      required:
+        - index
+        - type
+
+    MessageContentImageUrlObject:
+      title: Image URL
+      type: object
+      description: References an image URL in the content of a message.
+      properties:
+        type:
+          type: string
+          enum: ["image_url"]
+          description: The type of the content part.
+        image_url:
+          type: object
+          properties:
+            url:
+              type: string
+              description: "The external URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+              format: uri
+            detail:
+              type: string
+              description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`. Default value is `auto`
+              enum: ["auto", "low", "high"]
+              default: "auto"
+          required:
+            - url
+      required:
+        - type
+        - image_url
+
+    MessageDeltaContentImageUrlObject:
+      title: Image URL
+      type: object
+      description: References an image URL in the content of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `image_url`.
+          type: string
+          enum: ["image_url"]
+        image_url:
+          type: object
+          properties:
+            url:
+              description: "The URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp."
+              type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image. `low` uses fewer tokens, you can opt in to high resolution using `high`.
+              enum: ["auto", "low", "high"]
+              default: "auto"
+      required:
+        - index
+        - type
 
     MessageContentTextObject:
       title: Text
@@ -8167,10 +11341,26 @@ components:
         - type
         - text
 
+    MessageRequestContentTextObject:
+      title: Text
+      type: object
+      description: The text content that is part of a message.
+      properties:
+        type:
+          description: Always `text`.
+          type: string
+          enum: ["text"]
+        text:
+          type: string
+          description: Text content to be sent to the model
+      required:
+        - type
+        - text
+
     MessageContentTextAnnotationsFileCitationObject:
       title: File citation
       type: object
-      description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "retrieval" tool to search files.
+      description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
       properties:
         type:
           description: Always `file_citation`.
@@ -8236,6 +11426,100 @@ components:
         - file_path
         - start_index
         - end_index
+
+    MessageDeltaContentTextObject:
+      title: Text
+      type: object
+      description: The text content that is part of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `text`.
+          type: string
+          enum: ["text"]
+        text:
+          type: object
+          properties:
+            value:
+              description: The data that makes up the text.
+              type: string
+            annotations:
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFileCitationObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFilePathObject"
+                x-oaiExpandable: true
+      required:
+        - index
+        - type
+
+    MessageDeltaContentTextAnnotationsFileCitationObject:
+      title: File citation
+      type: object
+      description: A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "file_search" tool to search files.
+      properties:
+        index:
+          type: integer
+          description: The index of the annotation in the text content part.
+        type:
+          description: Always `file_citation`.
+          type: string
+          enum: ["file_citation"]
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_citation:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the specific File the citation is from.
+              type: string
+            quote:
+              description: The specific quote in the file.
+              type: string
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - index
+        - type
+
+    MessageDeltaContentTextAnnotationsFilePathObject:
+      title: File path
+      type: object
+      description: A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.
+      properties:
+        index:
+          type: integer
+          description: The index of the annotation in the text content part.
+        type:
+          description: Always `file_path`.
+          type: string
+          enum: ["file_path"]
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_path:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the file that was generated.
+              type: string
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - index
+        - type
 
     RunStepObject:
       type: object
@@ -8337,6 +11621,56 @@ components:
         beta: true
         example: *run_step_object_example
 
+    RunStepDeltaObject:
+      type: object
+      title: Run step delta object
+      description: |
+        Represents a run step delta i.e. any changed fields on a run step during streaming.
+      properties:
+        id:
+          description: The identifier of the run step, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.run.step.delta`.
+          type: string
+          enum: ["thread.run.step.delta"]
+        delta:
+          description: The delta containing the fields that have changed on the run step.
+          type: object
+          properties:
+            step_details:
+              type: object
+              description: The details of the run step.
+              oneOf:
+                - $ref: "#/components/schemas/RunStepDeltaStepDetailsMessageCreationObject"
+                - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsObject"
+              x-oaiExpandable: true
+      required:
+        - id
+        - object
+        - delta
+      x-oaiMeta:
+        name: The run step delta object
+        beta: true
+        example: |
+          {
+            "id": "step_123",
+            "object": "thread.run.step.delta",
+            "delta": {
+              "step_details": {
+                "type": "tool_calls",
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "code_interpreter",
+                    "code_interpreter": { "input": "", "outputs": [] }
+                  }
+                ]
+              }
+            }
+          }
+
     ListRunStepsResponse:
       properties:
         object:
@@ -8383,6 +11717,24 @@ components:
         - type
         - message_creation
 
+    RunStepDeltaStepDetailsMessageCreationObject:
+      title: Message creation
+      type: object
+      description: Details of the message creation by the run step.
+      properties:
+        type:
+          description: Always `message_creation`.
+          type: string
+          enum: ["message_creation"]
+        message_creation:
+          type: object
+          properties:
+            message_id:
+              type: string
+              description: The ID of the message that was created by this run step.
+      required:
+        - type
+
     RunStepDetailsToolCallsObject:
       title: Tool calls
       type: object
@@ -8395,19 +11747,41 @@ components:
         tool_calls:
           type: array
           description: |
-            An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `retrieval`, or `function`.
+            An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
           items:
             oneOf:
               - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeObject"
-              - $ref: "#/components/schemas/RunStepDetailsToolCallsRetrievalObject"
+              - $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchObject"
               - $ref: "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
             x-oaiExpandable: true
       required:
         - type
         - tool_calls
 
+    RunStepDeltaStepDetailsToolCallsObject:
+      title: Tool calls
+      type: object
+      description: Details of the tool call.
+      properties:
+        type:
+          description: Always `tool_calls`.
+          type: string
+          enum: ["tool_calls"]
+        tool_calls:
+          type: array
+          description: |
+            An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `file_search`, or `function`.
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeObject"
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFileSearchObject"
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFunctionObject"
+            x-oaiExpandable: true
+      required:
+        - type
+
     RunStepDetailsToolCallsCodeObject:
-      title: Code interpreter tool call
+      title: Code Interpreter tool call
       type: object
       description: Details of the Code Interpreter tool call the run step was involved in.
       properties:
@@ -8442,8 +11816,43 @@ components:
         - type
         - code_interpreter
 
+    RunStepDeltaStepDetailsToolCallsCodeObject:
+      title: Code interpreter tool call
+      type: object
+      description: Details of the Code Interpreter tool call the run step was involved in.
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `code_interpreter` for this type of tool call.
+          enum: ["code_interpreter"]
+        code_interpreter:
+          type: object
+          description: The Code Interpreter tool call definition.
+          properties:
+            input:
+              type: string
+              description: The input to the Code Interpreter tool call.
+            outputs:
+              type: array
+              description: The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.
+              items:
+                type: object
+                oneOf:
+                  - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject"
+                  - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputImageObject"
+                x-oaiExpandable: true
+      required:
+        - index
+        - type
+
     RunStepDetailsToolCallsCodeOutputLogsObject:
-      title: Code interpreter log output
+      title: Code Interpreter log output
       type: object
       description: Text output from the Code Interpreter tool call as part of a run step.
       properties:
@@ -8458,8 +11867,27 @@ components:
         - type
         - logs
 
+    RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject:
+      title: Code interpreter log output
+      type: object
+      description: Text output from the Code Interpreter tool call as part of a run step.
+      properties:
+        index:
+          type: integer
+          description: The index of the output in the outputs array.
+        type:
+          description: Always `logs`.
+          type: string
+          enum: ["logs"]
+        logs:
+          type: string
+          description: The text output from the Code Interpreter tool call.
+      required:
+        - index
+        - type
+
     RunStepDetailsToolCallsCodeOutputImageObject:
-      title: Code interpreter image output
+      title: Code Interpreter image output
       type: object
       properties:
         type:
@@ -8478,8 +11906,29 @@ components:
         - type
         - image
 
-    RunStepDetailsToolCallsRetrievalObject:
-      title: Retrieval tool call
+    RunStepDeltaStepDetailsToolCallsCodeOutputImageObject:
+      title: Code interpreter image output
+      type: object
+      properties:
+        index:
+          type: integer
+          description: The index of the output in the outputs array.
+        type:
+          description: Always `image`.
+          type: string
+          enum: ["image"]
+        image:
+          type: object
+          properties:
+            file_id:
+              description: The [file](/docs/api-reference/files) ID of the image.
+              type: string
+      required:
+        - index
+        - type
+
+    RunStepDetailsToolCallsFileSearchObject:
+      title: File search tool call
       type: object
       properties:
         id:
@@ -8487,16 +11936,39 @@ components:
           description: The ID of the tool call object.
         type:
           type: string
-          description: The type of tool call. This is always going to be `retrieval` for this type of tool call.
-          enum: ["retrieval"]
-        retrieval:
+          description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+          enum: ["file_search"]
+        file_search:
           type: object
           description: For now, this is always going to be an empty object.
           x-oaiTypeLabel: map
       required:
         - id
         - type
-        - retrieval
+        - file_search
+
+    RunStepDeltaStepDetailsToolCallsFileSearchObject:
+      title: File search tool call
+      type: object
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `file_search` for this type of tool call.
+          enum: ["file_search"]
+        file_search:
+          type: object
+          description: For now, this is always going to be an empty object.
+          x-oaiTypeLabel: map
+      required:
+        - index
+        - type
+        - file_search
 
     RunStepDetailsToolCallsFunctionObject:
       type: object
@@ -8532,53 +12004,218 @@ components:
         - type
         - function
 
-    AssistantFileObject:
+    RunStepDeltaStepDetailsToolCallsFunctionObject:
       type: object
-      title: Assistant files
-      description: A list of [Files](/docs/api-reference/files) attached to an `assistant`.
+      title: Function tool call
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `function` for this type of tool call.
+          enum: ["function"]
+        function:
+          type: object
+          description: The definition of the function that was called.
+          properties:
+            name:
+              type: string
+              description: The name of the function.
+            arguments:
+              type: string
+              description: The arguments passed to the function.
+            output:
+              type: string
+              description: The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.
+              nullable: true
+      required:
+        - index
+        - type
+
+    VectorStoreExpirationAfter:
+      type: object
+      title: Vector store expiration policy
+      description: The expiration policy for a vector store.
+      properties:
+        anchor:
+          description: "Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`."
+          type: string
+          enum: ["last_active_at"]
+        days:
+          description: The number of days after the anchor time that the vector store will expire.
+          type: integer
+          minimum: 1
+          maximum: 365
+      required:
+        - anchor
+        - days
+
+    VectorStoreObject:
+      type: object
+      title: Vector store
+      description: A vector store is a collection of processed files can be used by the `file_search` tool.
       properties:
         id:
           description: The identifier, which can be referenced in API endpoints.
           type: string
         object:
-          description: The object type, which is always `assistant.file`.
+          description: The object type, which is always `vector_store`.
           type: string
-          enum: [assistant.file]
+          enum: ["vector_store"]
         created_at:
-          description: The Unix timestamp (in seconds) for when the assistant file was created.
+          description: The Unix timestamp (in seconds) for when the vector store was created.
           type: integer
-        assistant_id:
-          description: The assistant ID that the file is attached to.
+        name:
+          description: The name of the vector store.
           type: string
+        usage_bytes:
+          description: The total number of bytes used by the files in the vector store.
+          type: integer
+        file_counts:
+          type: object
+          properties:
+            in_progress:
+              description: The number of files that are currently being processed.
+              type: integer
+            completed:
+              description: The number of files that have been successfully processed.
+              type: integer
+            failed:
+              description: The number of files that have failed to process.
+              type: integer
+            cancelled:
+              description: The number of files that were cancelled.
+              type: integer
+            total:
+              description: The total number of files.
+              type: integer
+          required:
+            - in_progress
+            - completed
+            - failed
+            - cancelled
+            - total
+        status:
+          description: The status of the vector store, which can be either `expired`, `in_progress`, or `completed`. A status of `completed` indicates that the vector store is ready for use.
+          type: string
+          enum: ["expired", "in_progress", "completed"]
+        expires_after:
+          $ref: "#/components/schemas/VectorStoreExpirationAfter"
+        expires_at:
+          description: The Unix timestamp (in seconds) for when the vector store will expire.
+          type: integer
+          nullable: true
+        last_active_at:
+          description: The Unix timestamp (in seconds) for when the vector store was last active.
+          type: integer
+          nullable: true
+        metadata:
+          description: *metadata_description
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
       required:
         - id
         - object
+        - usage_bytes
         - created_at
-        - assistant_id
+        - status
+        - last_active_at
+        - name
+        - file_counts
+        - metadata
       x-oaiMeta:
-        name: The assistant file object
+        name: The vector store object
         beta: true
         example: |
           {
-            "id": "file-abc123",
-            "object": "assistant.file",
-            "created_at": 1699055364,
-            "assistant_id": "asst_abc123"
+            "id": "vs_123",
+            "object": "vector_store",
+            "created_at": 1698107661,
+            "usage_bytes": 123456,
+            "last_active_at": 1698107661,
+            "name": "my_vector_store",
+            "status": "completed",
+            "file_counts": {
+              "in_progress": 0,
+              "completed": 100,
+              "cancelled": 0,
+              "failed": 0,
+              "total": 100
+            },
+            "metadata": {},
+            "last_used_at": 1698107661
           }
 
-    CreateAssistantFileRequest:
+    CreateVectorStoreRequest:
       type: object
       additionalProperties: false
       properties:
-        file_id:
-          description: A [File](/docs/api-reference/files) ID (with `purpose="assistants"`) that the assistant should use. Useful for tools like `retrieval` and `code_interpreter` that can access files.
+        file_ids:
+          description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+          type: array
+          maxItems: 500
+          items:
+            type: string
+        name:
+          description: The name of the vector store.
           type: string
-      required:
-        - file_id
+        expires_after:
+          $ref: "#/components/schemas/VectorStoreExpirationAfter"
+        metadata:
+          description: *metadata_description
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
 
-    DeleteAssistantFileResponse:
+    UpdateVectorStoreRequest:
       type: object
-      description: Deletes the association between the assistant and the file, but does not delete the [File](/docs/api-reference/files) object itself.
+      additionalProperties: false
+      properties:
+        name:
+          description: The name of the vector store.
+          type: string
+          nullable: true
+        expires_after:
+          $ref: "#/components/schemas/VectorStoreExpirationAfter"
+          nullable: true
+        metadata:
+          description: *metadata_description
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+
+    ListVectorStoresResponse:
+      properties:
+        object:
+          type: string
+          example: "list"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/VectorStoreObject"
+        first_id:
+          type: string
+          example: "vs_abc123"
+        last_id:
+          type: string
+          example: "vs_abc456"
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+
+    DeleteVectorStoreResponse:
+      type: object
       properties:
         id:
           type: string
@@ -8586,73 +12223,91 @@ components:
           type: boolean
         object:
           type: string
-          enum: [assistant.file.deleted]
+          enum: [vector_store.deleted]
       required:
         - id
         - object
         - deleted
-    ListAssistantFilesResponse:
-      properties:
-        object:
-          type: string
-          example: "list"
-        data:
-          type: array
-          items:
-            $ref: "#/components/schemas/AssistantFileObject"
-        first_id:
-          type: string
-          example: "file-abc123"
-        last_id:
-          type: string
-          example: "file-abc456"
-        has_more:
-          type: boolean
-          example: false
-      required:
-        - object
-        - data
-        - items
-        - first_id
-        - last_id
-        - has_more
 
-    MessageFileObject:
+    VectorStoreFileObject:
       type: object
-      title: Message files
-      description: A list of files attached to a `message`.
+      title: Vector store files
+      description: A list of files attached to a vector store.
       properties:
         id:
           description: The identifier, which can be referenced in API endpoints.
           type: string
         object:
-          description: The object type, which is always `thread.message.file`.
+          description: The object type, which is always `vector_store.file`.
           type: string
-          enum: ["thread.message.file"]
-        created_at:
-          description: The Unix timestamp (in seconds) for when the message file was created.
+          enum: ["vector_store.file"]
+        usage_bytes:
+          description: The total vector store usage in bytes. Note that this may be different from the original file size.
           type: integer
-        message_id:
-          description: The ID of the [message](/docs/api-reference/messages) that the [File](/docs/api-reference/files) is attached to.
+        created_at:
+          description: The Unix timestamp (in seconds) for when the vector store file was created.
+          type: integer
+        vector_store_id:
+          description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
           type: string
+        status:
+          description: The status of the vector store file, which can be either `in_progress`, `completed`, `cancelled`, or `failed`. The status `completed` indicates that the vector store file is ready for use.
+          type: string
+          enum: ["in_progress", "completed", "cancelled", "failed"]
+        last_error:
+          type: object
+          description: The last error associated with this vector store file. Will be `null` if there are no errors.
+          nullable: true
+          properties:
+            code:
+              type: string
+              description: One of `server_error` or `rate_limit_exceeded`.
+              enum:
+                [
+                  "internal_error",
+                  "file_not_found",
+                  "parsing_error",
+                  "unhandled_mime_type",
+                ]
+            message:
+              type: string
+              description: A human-readable description of the error.
+          required:
+            - code
+            - message
       required:
         - id
         - object
+        - usage_bytes
         - created_at
-        - message_id
+        - vector_store_id
+        - status
+        - last_error
       x-oaiMeta:
-        name: The message file object
+        name: The vector store file object
         beta: true
         example: |
           {
             "id": "file-abc123",
-            "object": "thread.message.file",
+            "object": "vector_store.file",
+            "usage_bytes": 1234,
             "created_at": 1698107661,
-            "message_id": "message_QLoItBbqwyAJEzlTy4y9kOMM",
-            "file_id": "file-abc123"
+            "vector_store_id": "vs_abc123",
+            "status": "completed",
+            "last_error": null
           }
 
-    ListMessageFilesResponse:
+    CreateVectorStoreFileRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file_id:
+          description: A [File](/docs/api-reference/files) ID that the vector store should use. Useful for tools like `file_search` that can access files.
+          type: string
+      required:
+        - file_id
+
+    ListVectorStoreFilesResponse:
       properties:
         object:
           type: string
@@ -8660,7 +12315,7 @@ components:
         data:
           type: array
           items:
-            $ref: "#/components/schemas/MessageFileObject"
+            $ref: "#/components/schemas/VectorStoreFileObject"
         first_id:
           type: string
           example: "file-abc123"
@@ -8673,14 +12328,687 @@ components:
       required:
         - object
         - data
-        - items
         - first_id
         - last_id
         - has_more
 
+    DeleteVectorStoreFileResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum: [vector_store.file.deleted]
+      required:
+        - id
+        - object
+        - deleted
+
+    VectorStoreFileBatchObject:
+      type: object
+      title: Vector store file batch
+      description: A batch of files attached to a vector store.
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `vector_store.file_batch`.
+          type: string
+          enum: ["vector_store.files_batch"]
+        created_at:
+          description: The Unix timestamp (in seconds) for when the vector store files batch was created.
+          type: integer
+        vector_store_id:
+          description: The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files) is attached to.
+          type: string
+        status:
+          description: The status of the vector store files batch, which can be either `in_progress`, `completed`, `cancelled` or `failed`.
+          type: string
+          enum: ["in_progress", "completed", "cancelled", "failed"]
+        file_counts:
+          type: object
+          properties:
+            in_progress:
+              description: The number of files that are currently being processed.
+              type: integer
+            completed:
+              description: The number of files that have been processed.
+              type: integer
+            failed:
+              description: The number of files that have failed to process.
+              type: integer
+            cancelled:
+              description: The number of files that where cancelled.
+              type: integer
+            total:
+              description: The total number of files.
+              type: integer
+          required:
+            - in_progress
+            - completed
+            - cancelled
+            - failed
+            - total
+      required:
+        - id
+        - object
+        - created_at
+        - vector_store_id
+        - status
+        - file_counts
+      x-oaiMeta:
+        name: The vector store files batch object
+        beta: true
+        example: |
+          {
+            "id": "vsfb_123",
+            "object": "vector_store.files_batch",
+            "created_at": 1698107661,
+            "vector_store_id": "vs_abc123",
+            "status": "completed",
+            "file_counts": {
+              "in_progress": 0,
+              "completed": 100,
+              "failed": 0,
+              "cancelled": 0,
+              "total": 100
+            }
+          }
+
+    CreateVectorStoreFileBatchRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file_ids:
+          description: A list of [File](/docs/api-reference/files) IDs that the vector store should use. Useful for tools like `file_search` that can access files.
+          type: array
+          minItems: 1
+          maxItems: 500
+          items:
+            type: string
+      required:
+        - file_ids
+
+    AssistantStreamEvent:
+      description: |
+        Represents an event emitted when streaming a Run.
+
+        Each event in a server-sent events stream has an `event` and `data` property:
+
+        ```
+        event: thread.created
+        data: {"id": "thread_123", "object": "thread", ...}
+        ```
+
+        We emit events whenever a new object is created, transitions to a new state, or is being
+        streamed in parts (deltas). For example, we emit `thread.run.created` when a new run
+        is created, `thread.run.completed` when a run completes, and so on. When an Assistant chooses
+        to create a message during a run, we emit a `thread.message.created event`, a
+        `thread.message.in_progress` event, many `thread.message.delta` events, and finally a
+        `thread.message.completed` event.
+
+        We may add additional events over time, so we recommend handling unknown events gracefully
+        in your code. See the [Assistants API quickstart](/docs/assistants/overview) to learn how to
+        integrate the Assistants API with streaming.
+      oneOf:
+        - $ref: "#/components/schemas/ThreadStreamEvent"
+        - $ref: "#/components/schemas/RunStreamEvent"
+        - $ref: "#/components/schemas/RunStepStreamEvent"
+        - $ref: "#/components/schemas/MessageStreamEvent"
+        - $ref: "#/components/schemas/ErrorEvent"
+        - $ref: "#/components/schemas/DoneEvent"
+      x-oaiMeta:
+        name: Assistant stream events
+        beta: true
+
+    ThreadStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.created"]
+            data:
+              $ref: "#/components/schemas/ThreadObject"
+          required:
+            - event
+            - data
+          description: Occurs when a new [thread](/docs/api-reference/threads/object) is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [thread](/docs/api-reference/threads/object)"
+
+    RunStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.created"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a new [run](/docs/api-reference/runs/object) is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.queued"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `queued` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.in_progress"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to an `in_progress` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.requires_action"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `requires_action` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.completed"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.failed"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) fails.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.cancelling"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a `cancelling` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.cancelled"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) is cancelled.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.expired"]
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) expires.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+
+    RunStepStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.created"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.in_progress"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) moves to an `in_progress` state.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.delta"]
+            data:
+              $ref: "#/components/schemas/RunStepDeltaObject"
+          required:
+            - event
+            - data
+          description: Occurs when parts of a [run step](/docs/api-reference/runs/step-object) are being streamed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step delta](/docs/api-reference/assistants-streaming/run-step-delta-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.completed"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.failed"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) fails.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.cancelled"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) is cancelled.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.run.step.expired"]
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/runs/step-object) expires.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/runs/step-object)"
+
+    MessageStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.message.created"]
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.message.in_progress"]
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) moves to an `in_progress` state.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.message.delta"]
+            data:
+              $ref: "#/components/schemas/MessageDeltaObject"
+          required:
+            - event
+            - data
+          description: Occurs when parts of a [Message](/docs/api-reference/messages/object) are being streamed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message delta](/docs/api-reference/assistants-streaming/message-delta-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.message.completed"]
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum: ["thread.message.incomplete"]
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) ends before it is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+
+    ErrorEvent:
+      type: object
+      properties:
+        event:
+          type: string
+          enum: ["error"]
+        data:
+          $ref: "#/components/schemas/Error"
+      required:
+        - event
+        - data
+      description: Occurs when an [error](/docs/guides/error-codes/api-errors) occurs. This can happen due to an internal server error or a timeout.
+      x-oaiMeta:
+        dataDescription: "`data` is an [error](/docs/guides/error-codes/api-errors)"
+
+    DoneEvent:
+      type: object
+      properties:
+        event:
+          type: string
+          enum: ["done"]
+        data:
+          type: string
+          enum: ["[DONE]"]
+      required:
+        - event
+        - data
+      description: Occurs when a stream ends.
+      x-oaiMeta:
+        dataDescription: "`data` is `[DONE]`"
+
+    Batch:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum: [batch]
+          description: The object type, which is always `batch`.
+        endpoint:
+          type: string
+          description: The OpenAI API endpoint used by the batch.
+
+        errors:
+          type: object
+          properties:
+            object:
+              type: string
+              description: The object type, which is always `list`.
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    description: An error code identifying the error type.
+                  message:
+                    type: string
+                    description: A human-readable message providing more details about the error.
+                  param:
+                    type: string
+                    description: The name of the parameter that caused the error, if applicable.
+                    nullable: true
+                  line:
+                    type: integer
+                    description: The line number of the input file where the error occurred, if applicable.
+                    nullable: true
+        input_file_id:
+          type: string
+          description: The ID of the input file for the batch.
+        completion_window:
+          type: string
+          description: The time frame within which the batch should be processed.
+        status:
+          type: string
+          description: The current status of the batch.
+          enum:
+            - validating
+            - failed
+            - in_progress
+            - finalizing
+            - completed
+            - expired
+            - cancelling
+            - cancelled
+        output_file_id:
+          type: string
+          description: The ID of the file containing the outputs of successfully executed requests.
+        error_file_id:
+          type: string
+          description: The ID of the file containing the outputs of requests with errors.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was created.
+        in_progress_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started processing.
+        expires_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch will expire.
+        finalizing_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started finalizing.
+        completed_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was completed.
+        failed_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch failed.
+        expired_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch expired.
+        cancelling_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started cancelling.
+        cancelled_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was cancelled.
+        request_counts:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Total number of requests in the batch.
+            completed:
+              type: integer
+              description: Number of requests that have been completed successfully.
+            failed:
+              type: integer
+              description: Number of requests that have failed.
+          required:
+            - total
+            - completed
+            - failed
+          description: The request counts for different statuses within the batch.
+        metadata:
+          description: *metadata_description
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+      required:
+        - id
+        - object
+        - endpoint
+        - input_file_id
+        - completion_window
+        - status
+        - created_at
+      x-oaiMeta:
+        name: The batch object
+        example: *batch_object
+
+    BatchRequestInput:
+      type: object
+      description: The per-line object of the batch input file
+      properties:
+        custom_id:
+          type: string
+          description: A developer-provided per-request id that will be used to match outputs to inputs. Must be unique for each request in a batch.
+        method:
+          type: string
+          enum: ["POST"]
+          description: The HTTP method to be used for the request. Currently only `POST` is supported.
+        url:
+          type: string
+          description: The OpenAI API relative URL to be used for the request. Currently `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are supported.
+      x-oaiMeta:
+        name: The request input object
+        example: |
+          {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-3.5-turbo", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What is 2+2?"}]}}
+
+    BatchRequestOutput:
+      type: object
+      description: The per-line object of the batch output and error files
+      properties:
+        id:
+          type: string
+        custom_id:
+          type: string
+          description: A developer-provided per-request id that will be used to match outputs to inputs.
+        response:
+          type: object
+          nullable: true
+          properties:
+            status_code:
+              type: integer
+              description: The HTTP status code of the response
+            request_id:
+              type: string
+              description: An unique identifier for the OpenAI API request. Please include this request ID when contacting support.
+            body:
+              type: object
+              x-oaiTypeLabel: map
+              description: The JSON body of the response
+        error:
+          type: object
+          nullable: true
+          description: For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure.
+          properties:
+            code:
+              type: string
+              description: A machine-readable error code.
+            message:
+              type: string
+              description: A human-readable error message.
+      x-oaiMeta:
+        name: The request output object
+        example: |
+          {"id": "batch_req_wnaDys", "custom_id": "request-2", "response": {"status_code": 200, "request_id": "req_c187b3", "body": {"id": "chatcmpl-9758Iw", "object": "chat.completion", "created": 1711475054, "model": "gpt-3.5-turbo", "choices": [{"index": 0, "message": {"role": "assistant", "content": "2 + 2 equals 4."}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 24, "completion_tokens": 15, "total_tokens": 39}, "system_fingerprint": null}}, "error": null}
+
+    ListBatchesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Batch"
+        first_id:
+          type: string
+          example: "batch_abc123"
+        last_id:
+          type: string
+          example: "batch_abc456"
+        has_more:
+          type: boolean
+        object:
+          type: string
+          enum: [list]
+      required:
+        - object
+        - data
+        - has_more
+
 security:
   - ApiKeyAuth: []
+
 x-oaiMeta:
+  navigationGroups:
+    - id: endpoints
+      title: Endpoints
+    - id: assistants
+      title: Assistants
+    - id: legacy
+      title: Legacy
   groups:
     # > General Notes
     # The `groups` section is used to generate the API reference pages and navigation, in the same
@@ -8709,6 +13037,7 @@ x-oaiMeta:
         Learn how to turn audio into text or text into audio.
 
         Related guide: [Speech to text](/docs/guides/speech-to-text)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createSpeech
@@ -8719,12 +13048,19 @@ x-oaiMeta:
         - type: endpoint
           key: createTranslation
           path: createTranslation
+        - type: object
+          key: CreateTranscriptionResponseJson
+          path: json-object
+        - type: object
+          key: CreateTranscriptionResponseVerboseJson
+          path: verbose-json-object
     - id: chat
       title: Chat
       description: |
         Given a list of messages comprising a conversation, the model will return a response.
 
         Related guide: [Chat Completions](/docs/guides/text-generation)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createChatCompletion
@@ -8741,6 +13077,7 @@ x-oaiMeta:
         Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
 
         Related guide: [Embeddings](/docs/guides/embeddings)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createEmbedding
@@ -8754,6 +13091,7 @@ x-oaiMeta:
         Manage fine-tuning jobs to tailor a model to your specific training data.
 
         Related guide: [Fine-tune models](/docs/guides/fine-tuning)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createFineTuningJob
@@ -8764,6 +13102,9 @@ x-oaiMeta:
         - type: endpoint
           key: listFineTuningEvents
           path: list-events
+        - type: endpoint
+          key: listFineTuningJobCheckpoints
+          path: list-checkpoints
         - type: endpoint
           key: retrieveFineTuningJob
           path: retrieve
@@ -8776,10 +13117,43 @@ x-oaiMeta:
         - type: object
           key: FineTuningJobEvent
           path: event-object
+        - type: object
+          key: FineTuningJobCheckpoint
+          path: checkpoint-object
+    - id: batch
+      title: Batch
+      description: |
+        Create large batches of API requests for asynchronous processing. The Batch API returns completions within 24 hours for a 50% discount.
+
+        Related guide: [Batch](/docs/guides/batch)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createBatch
+          path: create
+        - type: endpoint
+          key: retrieveBatch
+          path: retrieve
+        - type: endpoint
+          key: cancelBatch
+          path: cancel
+        - type: endpoint
+          key: listBatches
+          path: list
+        - type: object
+          key: Batch
+          path: object
+        - type: object
+          key: BatchRequestInput
+          path: requestInput
+        - type: object
+          key: BatchRequestOutput
+          path: requestOutput
     - id: files
       title: Files
       description: |
-        Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants) and [Fine-tuning](/docs/api-reference/fine-tuning).
+        Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants), [Fine-tuning](/docs/api-reference/fine-tuning), and [Batch API](/docs/guides/batch).
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createFile
@@ -8805,6 +13179,7 @@ x-oaiMeta:
         Given a prompt and/or an input image, the model will generate a new image.
 
         Related guide: [Image generation](/docs/guides/images)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createImage
@@ -8822,6 +13197,7 @@ x-oaiMeta:
       title: Models
       description: |
         List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: listModels
@@ -8838,9 +13214,10 @@ x-oaiMeta:
     - id: moderations
       title: Moderations
       description: |
-        Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+        Given some input text, outputs if the model classifies it as potentially harmful across several categories.
 
         Related guide: [Moderations](/docs/guides/moderation)
+      navigationGroup: endpoints
       sections:
         - type: endpoint
           key: createModeration
@@ -8855,40 +13232,26 @@ x-oaiMeta:
         Build assistants that can call models and use tools to perform tasks.
 
         [Get started with the Assistants API](/docs/assistants)
+      navigationGroup: assistants
       sections:
         - type: endpoint
           key: createAssistant
           path: createAssistant
         - type: endpoint
-          key: createAssistantFile
-          path: createAssistantFile
-        - type: endpoint
           key: listAssistants
           path: listAssistants
         - type: endpoint
-          key: listAssistantFiles
-          path: listAssistantFiles
-        - type: endpoint
           key: getAssistant
           path: getAssistant
-        - type: endpoint
-          key: getAssistantFile
-          path: getAssistantFile
         - type: endpoint
           key: modifyAssistant
           path: modifyAssistant
         - type: endpoint
           key: deleteAssistant
           path: deleteAssistant
-        - type: endpoint
-          key: deleteAssistantFile
-          path: deleteAssistantFile
         - type: object
           key: AssistantObject
           path: object
-        - type: object
-          key: AssistantFileObject
-          path: file-object
     - id: threads
       title: Threads
       beta: true
@@ -8896,6 +13259,7 @@ x-oaiMeta:
         Create threads that assistants can interact with.
 
         Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
       sections:
         - type: endpoint
           key: createThread
@@ -8919,6 +13283,7 @@ x-oaiMeta:
         Create messages within threads
 
         Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
       sections:
         - type: endpoint
           key: createMessage
@@ -8927,23 +13292,17 @@ x-oaiMeta:
           key: listMessages
           path: listMessages
         - type: endpoint
-          key: listMessageFiles
-          path: listMessageFiles
-        - type: endpoint
           key: getMessage
           path: getMessage
         - type: endpoint
-          key: getMessageFile
-          path: getMessageFile
-        - type: endpoint
           key: modifyMessage
           path: modifyMessage
+        - type: endpoint
+          key: deleteMessage
+          path: deleteMessage
         - type: object
           key: MessageObject
           path: object
-        - type: object
-          key: MessageFileObject
-          path: file-object
     - id: runs
       title: Runs
       beta: true
@@ -8951,6 +13310,7 @@ x-oaiMeta:
         Represents an execution run on a thread.
 
         Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
       sections:
         - type: endpoint
           key: createRun
@@ -8962,14 +13322,8 @@ x-oaiMeta:
           key: listRuns
           path: listRuns
         - type: endpoint
-          key: listRunSteps
-          path: listRunSteps
-        - type: endpoint
           key: getRun
           path: getRun
-        - type: endpoint
-          key: getRunStep
-          path: getRunStep
         - type: endpoint
           key: modifyRun
           path: modifyRun
@@ -8982,14 +13336,128 @@ x-oaiMeta:
         - type: object
           key: RunObject
           path: object
+    - id: run-steps
+      title: Run Steps
+      beta: true
+      description: |
+        Represents the steps (model and tool calls) taken during the run.
+
+        Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: listRunSteps
+          path: listRunSteps
+        - type: endpoint
+          key: getRunStep
+          path: getRunStep
         - type: object
           key: RunStepObject
           path: step-object
+    - id: vector-stores
+      title: Vector Stores
+      beta: true
+      description: |
+        Vector stores are used to store files for use by the `file_search` tool.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStore
+          path: create
+        - type: endpoint
+          key: listVectorStores
+          path: list
+        - type: endpoint
+          key: getVectorStore
+          path: retrieve
+        - type: endpoint
+          key: modifyVectorStore
+          path: modify
+        - type: endpoint
+          key: deleteVectorStore
+          path: delete
+        - type: object
+          key: VectorStoreObject
+          path: object
+    - id: vector-stores-files
+      title: Vector Store Files
+      beta: true
+      description: |
+        Vector store files represent files inside a vector store.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStoreFile
+          path: createFile
+        - type: endpoint
+          key: listVectorStoreFiles
+          path: listFiles
+        - type: endpoint
+          key: getVectorStoreFile
+          path: getFile
+        - type: endpoint
+          key: deleteVectorStoreFile
+          path: deleteFile
+        - type: object
+          key: VectorStoreFileObject
+          path: file-object
+    - id: vector-stores-file-batches
+      title: Vector Store File Batches
+      beta: true
+      description: |
+        Vector store file batches represent operations to add multiple files to a vector store.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStoreFileBatch
+          path: createBatch
+        - type: endpoint
+          key: getVectorStoreFileBatch
+          path: getBatch
+        - type: endpoint
+          key: cancelVectorStoreFileBatch
+          path: cancelBatch
+        - type: endpoint
+          key: listFilesInVectorStoreBatch
+          path: listBatchFiles
+        - type: object
+          key: VectorStoreFileBatchObject
+          path: batch-object
+    - id: assistants-streaming
+      title: Streaming
+      beta: true
+      description: |
+        Stream the result of executing a Run or resuming a Run after submitting tool outputs.
+
+        You can stream events from the [Create Thread and Run](/docs/api-reference/runs/createThreadAndRun),
+        [Create Run](/docs/api-reference/runs/createRun), and [Submit Tool Outputs](/docs/api-reference/runs/submitToolOutputs)
+        endpoints by passing `"stream": true`. The response will be a [Server-Sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) stream.
+
+        Our Node and Python SDKs provide helpful utilities to make streaming easy. Reference the
+        [Assistants API quickstart](/docs/assistants/overview) to learn more.
+      navigationGroup: assistants
+      sections:
+        - type: object
+          key: MessageDeltaObject
+          path: message-delta-object
+        - type: object
+          key: RunStepDeltaObject
+          path: run-step-delta-object
+        - type: object
+          key: AssistantStreamEvent
+          path: events
     - id: completions
       title: Completions
       legacy: true
+      navigationGroup: legacy
       description: |
-        Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position. Most developer should use our [Chat Completions API](/docs/guides/text-generation/text-generation-models) to leverage our best and newest models. Most models that support the legacy Completions endpoint [will be shut off on January 4th, 2024](/docs/deprecations/2023-07-06-gpt-and-embeddings).
+        Given a prompt, the model will return one or more predicted completions along with the probabilities of alternative tokens at each position. Most developer should use our [Chat Completions API](/docs/guides/text-generation/text-generation-models) to leverage our best and newest models.
       sections:
         - type: endpoint
           key: createCompletion

--- a/src/wkok/openai_clojure/openai.clj
+++ b/src/wkok/openai_clojure/openai.clj
@@ -75,6 +75,11 @@
       (update-file-schema :create-image-edit (schema.core/optional-key :mask))
       (update-file-schema :create-image-variation :image)))
 
+(defn fix-tools? [m]
+  (martian/update-handler m :create-chat-completion
+                          (fn [op]
+                            (assoc-in op [:body-schema :body (schema.core/optional-key :tools)] schema.core/Any))))
+
 (defn bootstrap-openapi
   "Bootstrap the martian from a local copy of the openai swagger spec"
   []
@@ -115,6 +120,7 @@
                                                  :replace
                                                  :martian.interceptors/coerce-response))))]
     (-> (martian/bootstrap-openapi base-url definition opts)
-        update-file-schemas)))
+        update-file-schemas
+        fix-tools?)))
 
 (def m (delay (bootstrap-openapi)))


### PR DESCRIPTION
The events async channel does not ever get closed. Closing a channel is the best way to signal that a channel doesn't have any more info. Currently, the channel signals that it's done by putting a `:done` value on the channel. I think it would be preferable to just close the channel rather than send an unqualified `:done` as a sentinel, but I did not make that change since it would be backwards incompatible.

Closing the channel when the stream is finished also makes the channel compatible with existing builtin functions. For example:

```clojure
(def response
  (openai/create-chat-completion {:model "gpt-4o"
                                  :messages [{:role "system" :content "You are a helpful assistant."}
                                             {:role "user" :content "hi"}]
                                  :stream true}
                                 {:api-key openai-key}))


(def messages (async/<!! (async/into [] response))) 

```

The above works after applying the attached change. 