### PR TITLE
Make sure sse async channel gets closed.

### DIFF
--- a/src/wkok/openai_clojure/sse.clj
+++ b/src/wkok/openai_clojure/sse.clj
@@ -43,8 +43,9 @@
 (defn sse-events
   "Returns a core.async channel with events as clojure data structures.
   Inspiration from https://gist.github.com/oliyh/2b9b9107e7e7e12d4a60e79a19d056ee"
-  [{:keys [request params]}]
-  (let [event-stream ^InputStream (:body (http/request (merge request
+  [{:keys [request params] :as m}]
+  (let [close? (:stream/close? params)
+        event-stream ^InputStream (:body (http/request (merge request
                                                               params
                                                               {:as :stream})))
         buffer-size (calc-buffer-size params)
@@ -72,7 +73,8 @@
 
                   (recur next-byte-coll))))))
         (finally
-          (a/close! events)
+          (when close?
+            (a/close! events))
           (.close event-stream))))
     events))
 

--- a/src/wkok/openai_clojure/sse.clj
+++ b/src/wkok/openai_clojure/sse.clj
@@ -15,7 +15,7 @@
   (when on-next
     (a/go
       (loop []
-        (let [event (a/<! events)]
+        (when-let [event (a/<! events)]
           (when (not= :done event)
             (on-next event)
             (recur)))))))

--- a/test/wkok/openai_clojure/sse_test.clj
+++ b/test/wkok/openai_clojure/sse_test.clj
@@ -11,7 +11,11 @@
 (defn- generate-events
   [data-coll]
   (let [events (map #(str "data: " (json/generate-string %)) data-coll)]
-    (str/join "\n\n" (concat events ["data: [DONE]"]))))
+    (str/join
+     (eduction
+      cat
+      (map #(str % "\n\n"))
+      [events ["data: [DONE]"]]))))
 
 (defn- stream-string
   [^PipedOutputStream output-stream ^String s]
@@ -19,7 +23,8 @@
     (doseq [c (seq (.getBytes s))]
       (.write output-stream ^int c)
       (.flush output-stream)
-      (Thread/sleep 1))))
+      (Thread/sleep 1))
+    (.close output-stream)))
 
 (deftest sse-events-test
   (testing "channel can get events"
@@ -33,7 +38,48 @@
             (is (= (first test-data)
                    (a/<!! events)))
             (is (= (second test-data)
+                   (a/<!! events)))
+            (is (= :done
+                   (a/<!! events)))
+            (is (= nil
+                   (a/poll! events))))))))
+
+  (testing "channel events with `stream/close?` parameter"
+    (let [test-data [{:text "hello"} {:text "world"}]
+          test-events (generate-events test-data)]
+      (with-open [output-stream (PipedOutputStream.)
+                  input-stream (PipedInputStream. output-stream)]
+        (with-redefs [http/request (constantly {:body input-stream})]
+          (let [events (sse/sse-events {:params {:stream/close? true}})]
+            (stream-string output-stream test-events)
+            (is (= (first test-data)
+                   (a/<!! events)))
+            (is (= (second test-data)
+                   (a/<!! events)))
+            (is (= :done
+                   (a/<!! events)))
+            (is (= nil
                    (a/<!! events))))))))
+
+  (testing "channel events with `:on-next`"
+    (doseq [close? [true false]]
+      (let [test-data [{:text "hello"} {:text "world"}]
+            test-events (generate-events test-data)]
+        (with-open [output-stream (PipedOutputStream.)
+                    input-stream (PipedInputStream. output-stream)]
+          (with-redefs [http/request (constantly {:body input-stream})]
+            (let [events (sse/sse-events {:stream/close? close?})
+                  results (promise)
+                  ;; accumulate results and fulfill promise when done
+                  on-next (let [acc (volatile! [])]
+                            (fn [x]
+                              (vswap! acc conj x)
+                              (when (= x (last test-data))
+                                (deliver results @acc))))]
+              (sse/deliver-events events {:on-next on-next})
+              (stream-string output-stream test-events)
+              (is (= test-data
+                     @results))))))))
 
   (testing "support multibytes"
     (let [test-data [{:text "こんにちは"} {:text "你好"}]


### PR DESCRIPTION
The events async channel does not ever get closed. Closing a channel is the best way to signal that a channel doesn't have any more info. Currently, the channel signals that it's done by putting a `:done` value on the channel. I think it would be preferable to just close the channel rather than send an unqualified `:done` as a sentinel, but I did not make that change since it would be backwards incompatible.

Closing the channel when the stream is finished also makes the channel compatible with existing builtin functions. For example:

```clojure
(def response
  (openai/create-chat-completion {:model "gpt-4o"
                                  :messages [{:role "system" :content "You are a helpful assistant."}
                                             {:role "user" :content "hi"}]
                                  :stream true}
                                 {:api-key openai-key}))


(def messages (async/<!! (async/into [] response))) 

```

The above works after applying the attached change. 